### PR TITLE
feat: adicionado exemplo para internacionalização da extenção

### DIFF
--- a/commands/discloud/language.js
+++ b/commands/discloud/language.js
@@ -1,0 +1,26 @@
+const { Command } = require("../../structures/command");
+const vscode = require("vscode");
+
+module.exports = class extends Command {
+    constructor(discloud) {
+        super(discloud, {
+            name: "language",
+        });
+    }
+
+    run = async () => {
+        const input = await vscode.window.showQuickPick(this.discloud.textsSystem.languages, {
+            canPickMany: false,
+            title: this.discloud.textsSystem.getText({ folder: 'commands', text: 'language.selectLang', language: this.discloud.language }),
+        });
+
+        if (!input) {
+            vscode.window.showErrorMessage(this.discloud.textsSystem.getText({ folder: 'commands', text: 'language.mandatory', language: this.discloud.language }));
+            return;
+        }
+
+        vscode.workspace.getConfiguration("discloud").update("language", input, true);
+        this.discloud.language = input;
+        vscode.window.showInformationMessage(this.discloud.textsSystem.getText({ folder: 'commands', text: 'language.success', language: this.discloud.language, variables: { lang: input } }));
+    };
+};

--- a/languages/commands/en-US.json
+++ b/languages/commands/en-US.json
@@ -1,0 +1,7 @@
+{
+    "language": {
+        "selectLang": "Select the language",
+        "mandatory": "You have to choose which language you want to switch to",
+        "success": "Language successfully changed to {{lang}}"
+    }
+}

--- a/languages/commands/pt-BR.json
+++ b/languages/commands/pt-BR.json
@@ -1,0 +1,7 @@
+{
+    "language": {
+        "selectLang": "Selecione a língua",
+        "mandatory": "Tens de escolher para qual idioma queres trocar",
+        "success": "Linguagem alterada com sucesso para {{lang}}"
+    }
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "onCommand:discloud-apps.ramEntry",
     "onCommand:discloud-apps.backupEntry",
     "onCommand:discloud.logIn",
+    "onCommand:discloud.language",
     "onCommand:discloud.commit",
     "onCommand:discloud.upload",
     "onView:discloud-apps.refreshButton",
@@ -122,6 +123,10 @@
       {
         "command": "discloud.logIn",
         "title": "Login on Discloud"
+      },
+      {
+        "command": "discloud.language",
+        "title": "Change Language"
       }
     ],
     "viewsContainers": {

--- a/structures/TextsSystem.js
+++ b/structures/TextsSystem.js
@@ -1,0 +1,109 @@
+const { existsSync, lstatSync, readdirSync } = require('fs');
+const { resolve } = require('path');
+
+class TextsSystem {
+    constructor({ pathToTexts, defaultLanguage }) {
+        this.texts = {};
+        this.defaultLanguage = defaultLanguage;
+        this.pathToTexts = pathToTexts;
+        this.languages = [];
+        this.loadTexts();
+    }
+
+    async loadTexts() {
+        if (!this.checkIfIsFolder(this.pathToTexts)) {
+            throw new Error('Path to texts is not a folder');
+        }
+
+        const folders = readdirSync(this.pathToTexts);
+
+        for (const folder of folders) {
+            if (!folder || !this.checkIfIsFolder(resolve(this.pathToTexts, folder))) continue;
+            Object.assign(this.texts, this.loadFolder(resolve(this.pathToTexts, folder), folder));
+        }
+    }
+
+    checkIfIsFolder(path) {
+        return existsSync(path) && lstatSync(path).isDirectory();
+    }
+
+    loadFolder(pathToFolder, folder) {
+        const languages = [];
+        const texts = {};
+
+        const filesInsideFolder = readdirSync(pathToFolder);
+
+        for (const file of filesInsideFolder) {
+            if (!file) continue;
+
+            if (this.checkIfIsFolder(resolve(pathToFolder, file))) {
+                Object.assign(texts, this.loadFolder(resolve(pathToFolder, file), `${folder}/${file}`));
+            } else {
+                if (!file.endsWith('.json')) continue;
+
+                if (!texts[folder]) texts[folder] = {};
+
+                const language = file.split('.').shift();
+
+                if (!language) continue;
+
+                if (!languages.includes(language)) languages.push(language);
+
+                if (this.languages.includes(language)) this.languages.push(language);
+
+                texts[folder][language] = {};
+
+                texts[folder][language] = require(resolve(pathToFolder, file));
+            }
+        }
+
+        if (languages.length !== 0 && !languages.includes(this.defaultLanguage)) {
+            throw new Error(`Default language "${this.defaultLanguage}" not found in folder "${folder}"`);
+        }
+
+        return texts;
+    }
+
+    getText({
+        folder, text, language, variables}) {
+        let textToReturn = '';
+
+        if (!this.texts[folder]) {
+            throw new Error(`Folder "${folder}" not found`);
+        }
+
+        const folderData = this.texts[folder];
+
+        let textData = {};
+
+        if (!language) textData = folderData[this.defaultLanguage];
+        else if (folderData[language]) textData = folderData[language];
+        else textData = folderData[this.defaultLanguage];
+
+        if (!textData) {
+            throw new Error(`Language "${language}" not found in folder "${folder}"`);
+        }
+
+        const partsToText = text.split('.');
+
+        for (let i = 0; i < partsToText.length; i++) {
+            if (i === partsToText.length - 1) {
+                if (Array.isArray(textData[partsToText[i]])) textToReturn = textData[partsToText[i]].join('\n');
+                else textToReturn = textData[partsToText[i]];
+            }
+
+            textData = textData[partsToText[i]];
+        }
+
+        if (variables) {
+            for (const variable in variables) {
+                if (!variable || !variables[variable]) continue;
+                textToReturn = textToReturn.replace(new RegExp(`{{${variable}}}`, 'g'), variables[variable]);
+            }
+        }
+
+        return textToReturn;
+    }
+}
+
+module.exports = TextsSystem

--- a/structures/extend.js
+++ b/structures/extend.js
@@ -1,7 +1,8 @@
 const { readdirSync } = require("fs");
-const { join } = require("path");
+const { join, resolve } = require("path");
 const vscode = require("vscode");
 const { AppTreeDataProvider } = require("../functions/api/tree");
+const TextsSystem = require('./TextsSystem');
 
 
 module.exports = class Discloud {
@@ -14,6 +15,8 @@ module.exports = class Discloud {
     this.trees = new Map();
     this.mainTree;
     this.config = vscode.workspace.getConfiguration("discloud");
+    this.language = this.config.get("language") || 'pt-BR';
+    this.textsSystem = new TextsSystem({ pathToTexts: resolve(__dirname, '..', 'languages'), defaultLanguage: 'pt-BR' });
     this.loadCommands();
     this.loadStatusBar();
     this.loadTrees();


### PR DESCRIPTION
Falta acabar a troca dos textos para o sistema, tem um exemplo de como usar em `commands\discloud\language.js`