### PR TITLE
Refactor command methods to remove optional item parameters and handle responses consistently

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       {
         "command": "discloud.apps.import",
         "title": "%command.apps.import%",
-        "icon": "$(edit)"
+        "icon": "$(cloud-download)"
       },
       {
         "command": "discloud.apps.logs",
@@ -211,7 +211,7 @@
       {
         "command": "discloud.apps.status",
         "title": "%command.apps.status%",
-        "icon": "$(zap)"
+        "icon": "$(graph)"
       },
       {
         "command": "discloud.apps.stop",
@@ -335,7 +335,7 @@
       {
         "command": "discloud.team.status",
         "title": "%command.team.status%",
-        "icon": "$(zap)"
+        "icon": "$(graph)"
       },
       {
         "command": "discloud.team.stop",
@@ -866,7 +866,8 @@
         },
         {
           "command": "discloud.apps.status",
-          "when": "view == discloudUserApps && discloudAppLength"
+          "group": "inline",
+          "when": "view == discloudUserApps && discloudAppLength && viewItem =~ /^TreeItem/"
         },
         {
           "command": "discloud.apps.stop",
@@ -932,6 +933,7 @@
         },
         {
           "command": "discloud.team.status",
+          "group": "inline",
           "when": "view == discloudTeamApps && discloudTeamAppLength && viewItem =~ /^TreeItem/"
         },
         {
@@ -953,11 +955,6 @@
         {
           "command": "discloud.apps.refresh",
           "when": "view == discloudUserApps && !discloudTokenUnauthorized",
-          "group": "navigation"
-        },
-        {
-          "command": "discloud.apps.status",
-          "when": "view == discloudUserApps && discloudAppLength && !discloudTokenUnauthorized",
           "group": "navigation"
         },
         {
@@ -989,11 +986,6 @@
         {
           "command": "discloud.team.refresh",
           "when": "view == discloudTeamApps",
-          "group": "navigation"
-        },
-        {
-          "command": "discloud.team.status",
-          "when": "view == discloudTeamApps && discloudTeamAppLength && !discloudTokenUnauthorized",
           "group": "navigation"
         },
         {

--- a/src/commands/apps/backup.ts
+++ b/src/commands/apps/backup.ts
@@ -18,7 +18,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
+  async run(task: TaskData, item: AppTreeItem) {
     const workspaceAvailable = extension.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
     if (workspaceAvailable) workspaceFolder = await extension.getWorkspaceFolder();
@@ -27,22 +27,17 @@ export default class extends Command {
       if (!workspaceFolder) throw Error(t("no.folder.found"));
     }
 
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
+    const response = await extension.api.get<RESTGetApiAppBackupResult>(Routes.appBackup(item.appId));
+    if (!response) return;
 
-    const res = await extension.api.get<RESTGetApiAppBackupResult>(Routes.appBackup(item.appId));
-    if (!res) return;
+    if (!response.backups) throw Error(t("no.backup.found"));
 
-    if (!res.backups) throw Error(t("no.backup.found"));
-
-    const backup = await fetch(res.backups.url);
+    const backup = await fetch(response.backups.url);
     if (!backup.ok) throw Error(t("backup.request.failed"));
 
     const configBackupDir = extension.config.get<string>(ConfigKeys.appBackupDir) ?? "";
     const backupDirUri = workspaceAvailable ? Uri.joinPath(workspaceFolder, configBackupDir) : workspaceFolder;
-    const backupZipUri = Uri.joinPath(backupDirUri, `${res.backups.id}.zip`);
+    const backupZipUri = Uri.joinPath(backupDirUri, `${response.backups.id}.zip`);
 
     if (!existsSync(backupDirUri.fsPath))
       await workspace.fs.createDirectory(backupDirUri);

--- a/src/commands/apps/backup.ts
+++ b/src/commands/apps/backup.ts
@@ -44,6 +44,6 @@ export default class extends Command {
 
     await workspace.fs.writeFile(backupZipUri, Buffer.from(await backup.arrayBuffer()));
 
-    window.showInformationMessage(t("backup.success", { dir: backupZipUri.fsPath }));
+    await window.showInformationMessage(t("backup.success", { dir: backupZipUri.fsPath }));
   }
 }

--- a/src/commands/apps/commit.ts
+++ b/src/commands/apps/commit.ts
@@ -18,14 +18,9 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
+  async run(task: TaskData, item: AppTreeItem) {
     const workspaceFolder = await extension.getWorkspaceFolder();
     if (!workspaceFolder) throw Error(t("no.workspace.folder.found"));
-
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
 
     if (!await this.confirmAction())
       throw new CancellationError();
@@ -62,16 +57,16 @@ export default class extends Command {
 
     task.progress.report({ increment: -1, message: item.appId });
 
-    const res = await extension.api.put<RESTPutApiAppCommitResult>(Routes.appCommit(item.appId), { files });
+    const response = await extension.api.put<RESTPutApiAppCommitResult>(Routes.appCommit(item.appId), { files });
 
-    if (!res) return;
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.appTree.fetch();
 
-      if (res.logs) this.logger(item.output ?? item.appId, res.logs);
+      if (response.logs) this.logger(item.output ?? item.appId, response.logs);
     }
   }
 }

--- a/src/commands/apps/copy.id.ts
+++ b/src/commands/apps/copy.id.ts
@@ -3,7 +3,6 @@ import { env, window } from "vscode";
 import { type TaskData } from "../../@types";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
-import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
 export default class extends Command {
   constructor() {
@@ -12,14 +11,9 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item?: AppTreeItem | TeamAppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(null);
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     await env.clipboard.writeText(item.appId);
 
-    window.showInformationMessage(t("copied.appid"));
+    await window.showInformationMessage(t("copied.appid"));
   }
 }

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -16,22 +16,17 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.delete<RESTDeleteApiAppDeleteResult>(Routes.appDelete(item.appId));
-    if (!res) return;
+    const response = await extension.api.delete<RESTDeleteApiAppDeleteResult>(Routes.appDelete(item.appId));
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
-      if (res.status === "ok") {
+      if (response.status === "ok") {
         extension.appTree.delete(item.appId);
       }
     }

--- a/src/commands/apps/import.ts
+++ b/src/commands/apps/import.ts
@@ -19,7 +19,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
+  async run(task: TaskData, item: AppTreeItem) {
     const workspaceAvailable = extension.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
     if (workspaceAvailable) workspaceFolder = await extension.getWorkspaceFolder();
@@ -28,23 +28,18 @@ export default class extends Command {
       if (!workspaceFolder) throw Error(t("no.folder.found"));
     }
 
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
+    const response = await extension.api.get<RESTGetApiAppBackupResult>(Routes.appBackup(item.appId));
+    if (!response) return;
 
-    const res = await extension.api.get<RESTGetApiAppBackupResult>(Routes.appBackup(item.appId));
-    if (!res) return;
+    if (!response.backups) throw Error(t("no.backup.found"));
 
-    if (!res.backups) throw Error(t("no.backup.found"));
-
-    const backup = await fetch(res.backups.url);
+    const backup = await fetch(response.backups.url);
     if (!backup.body) throw Error(t("backup.request.failed"));
 
     const configImportDir = extension.config.get<string>(ConfigKeys.appImportDir) ?? "";
     const importDirUri = workspaceAvailable ? Uri.joinPath(workspaceFolder, configImportDir) : workspaceFolder;
-    const importUri = Uri.joinPath(importDirUri, res.backups.id);
-    const importZipUri = Uri.joinPath(importDirUri, `${res.backups.id}.zip`);
+    const importUri = Uri.joinPath(importDirUri, response.backups.id);
+    const importZipUri = Uri.joinPath(importDirUri, `${response.backups.id}.zip`);
 
     if (!existsSync(importDirUri.fsPath))
       await workspace.fs.createDirectory(importDirUri);

--- a/src/commands/apps/logs.ts
+++ b/src/commands/apps/logs.ts
@@ -16,17 +16,12 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
+  async run(_: TaskData, item: AppTreeItem) {
+    const response = await extension.api.get<RESTGetApiAppLogResult>(Routes.appLogs(item.appId));
+    if (!response) return;
 
-    const res = await extension.api.get<RESTGetApiAppLogResult>(Routes.appLogs(item.appId));
-    if (!res) return;
+    if (!response.apps || !response.apps.terminal.big) throw Error(t("no.log.found"));
 
-    if (!res.apps || !res.apps.terminal.big) throw Error(t("no.log.found"));
-
-    this.logger(item.output ?? res.apps.id, res.apps.terminal.big);
+    this.logger(item.output ?? response.apps.id, response.apps.terminal.big);
   }
 }

--- a/src/commands/apps/mods/add.ts
+++ b/src/commands/apps/mods/add.ts
@@ -16,12 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     const modID = await window.showInputBox({
       prompt: t("input.mod.add.prompt"),
     });
@@ -40,16 +35,16 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.post<RESTPostApiAppTeamResult>(Routes.appTeam(item.appId), {
+    const response = await extension.api.post<RESTPostApiAppTeamResult>(Routes.appTeam(item.appId), {
       body: {
         modID,
         perms,
       },
     });
-    if (!res) return;
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
     }
   }
 }

--- a/src/commands/apps/mods/edit.ts
+++ b/src/commands/apps/mods/edit.ts
@@ -16,12 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(task: TaskData, item: AppTreeItem) {
     const mod = await this.pickAppMod(item.appId, task);
     if (!mod) throw Error(t("missing.moderator"));
 
@@ -39,16 +34,16 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTPutApiAppTeamResult>(Routes.appTeam(item.appId), {
+    const response = await extension.api.put<RESTPutApiAppTeamResult>(Routes.appTeam(item.appId), {
       body: {
         modID: mod.id,
         perms,
       },
     });
-    if (!res) return;
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
     }
   }
 }

--- a/src/commands/apps/mods/rem.ts
+++ b/src/commands/apps/mods/rem.ts
@@ -16,23 +16,18 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(task: TaskData, item: AppTreeItem) {
     const mod = await this.pickAppMod(item.appId, task);
     if (!mod) throw Error(t("missing.moderator"));
 
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.delete<RESTDeleteApiAppTeamResult>(Routes.appTeam(item.appId, mod.id));
-    if (!res) return;
+    const response = await extension.api.delete<RESTDeleteApiAppTeamResult>(Routes.appTeam(item.appId, mod.id));
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
     }
   }
 }

--- a/src/commands/apps/profile/avatar.ts
+++ b/src/commands/apps/profile/avatar.ts
@@ -12,12 +12,7 @@ export default class extends Command {
     super();
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     const avatarURL = await InputBox.getExternalImageURL({
       prompt: t("input.avatar.prompt"),
       required: true,
@@ -26,13 +21,13 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { avatarURL } });
-    if (!res) return;
+    const response = await extension.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { avatarURL } });
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
-      if (res.status === "ok") {
+      if (response.status === "ok") {
         extension.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, avatarURL });
 
         const workspaceFolder = await extension.getWorkspaceFolder();

--- a/src/commands/apps/profile/name.ts
+++ b/src/commands/apps/profile/name.ts
@@ -11,12 +11,7 @@ export default class extends Command {
     super();
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     const name = await window.showInputBox({
       prompt: t("input.name.prompt"),
       validateInput(value) {
@@ -30,13 +25,13 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { name } });
-    if (!res) return;
+    const response = await extension.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { name } });
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
-      if (res.status === "ok") {
+      if (response.status === "ok") {
         extension.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, name });
 
         const workspaceFolder = await extension.getWorkspaceFolder();

--- a/src/commands/apps/ram.ts
+++ b/src/commands/apps/ram.ts
@@ -18,12 +18,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     const min = item.type === AppType.site ? 512 : 100;
     const max = extension.user.totalRamMb - (extension.user.ramUsedMb - item.data.ram);
 
@@ -39,11 +34,11 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTPutApiAppRamResult>(Routes.appRam(item.appId), { body: { ramMB } });
-    if (!res) return;
+    const response = await extension.api.put<RESTPutApiAppRamResult>(Routes.appRam(item.appId), { body: { ramMB } });
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.appTree.fetch();
     }

--- a/src/commands/apps/restart.ts
+++ b/src/commands/apps/restart.ts
@@ -16,20 +16,15 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTPutApiAppRestartResult>(Routes.appRestart(item.appId));
-    if (!res) return;
+    const response = await extension.api.put<RESTPutApiAppRestartResult>(Routes.appRestart(item.appId));
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.appTree.fetch();
     }

--- a/src/commands/apps/start.ts
+++ b/src/commands/apps/start.ts
@@ -16,17 +16,12 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
+  async run(_: TaskData, item: AppTreeItem) {
+    const response = await extension.api.put<RESTPutApiAppStartResult>(Routes.appStart(item.appId));
+    if (!response) return;
 
-    const res = await extension.api.put<RESTPutApiAppStartResult>(Routes.appStart(item.appId));
-    if (!res) return;
-
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.appTree.fetch();
     }

--- a/src/commands/apps/status.ts
+++ b/src/commands/apps/status.ts
@@ -1,6 +1,8 @@
 import { t } from "@vscode/l10n";
 import { ProgressLocation } from "vscode";
+import { type TaskData } from "../../@types";
 import extension from "../../extension";
+import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
@@ -13,8 +15,7 @@ export default class extends Command {
     });
   }
 
-  async run() {
-    if (extension.appTree.children.size)
-      await extension.appTree.getStatus();
+  async run(_: TaskData, item: AppTreeItem) {
+    await extension.appTree.getStatus(item.appId);
   }
 }

--- a/src/commands/apps/stop.ts
+++ b/src/commands/apps/stop.ts
@@ -16,20 +16,15 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTPutApiAppStartResult>(Routes.appStop(item.appId));
-    if (!res) return;
+    const response = await extension.api.put<RESTPutApiAppStartResult>(Routes.appStop(item.appId));
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.appTree.fetch();
     }

--- a/src/commands/apps/terminal.ts
+++ b/src/commands/apps/terminal.ts
@@ -9,12 +9,7 @@ export default class extends Command {
     super();
   }
 
-  async run(task: TaskData, item?: AppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: AppTreeItem) {
     const terminal = window.createTerminal({
       env: { DISCLOUD_TOKEN: extension.token },
       iconPath: item.iconPath as Uri,

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -62,22 +62,22 @@ export default class extends Command {
 
     task.progress.report({ increment: -1, message: t("committing") });
 
-    const res = await extension.api.put<RESTPutApiAppCommitResult>(
+    const response = await extension.api.put<RESTPutApiAppCommitResult>(
       picked.isApp ? Routes.appCommit(picked.id) : Routes.teamCommit(picked.id),
       { files },
     );
 
-    if (!res) return;
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       if (picked.isApp)
         await extension.appTree.fetch();
       else
         await extension.teamAppTree.fetch();
 
-      if (res.logs) this.logger(picked.app.output ?? picked.id, res.logs);
+      if (response.logs) this.logger(picked.app.output ?? picked.id, response.logs);
     }
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,7 +1,7 @@
 import { t } from "@vscode/l10n";
 import { window } from "vscode";
-import Command from "../structures/Command";
 import { tokenIsDiscloudJwt, tokenValidator } from "../services/discloud/utils";
+import Command from "../structures/Command";
 
 export default class extends Command {
   constructor() {
@@ -25,6 +25,6 @@ export default class extends Command {
     if (!await tokenValidator(input))
       throw Error(t("invalid.token"));
 
-    window.showInformationMessage(t("valid.token"));
+    await window.showInformationMessage(t("valid.token"));
   }
 }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -43,14 +43,15 @@ export default class extends Command {
       }
     }
 
-    const res = await extension.api.get<RESTGetApiAppLogResult>(item.isApp
+    const response = await extension.api.get<RESTGetApiAppLogResult>(item.isApp
       ? Routes.appLogs(item.appId)
       : Routes.teamLogs(item.appId));
-    if (!res) return;
 
-    if (!res.apps || !res.apps.terminal.big)
+    if (!response) return;
+
+    if (!response.apps || !response.apps.terminal.big)
       throw Error(t("no.log.found"));
 
-    this.logger(item.output ?? res.apps.id, res.apps.terminal.big);
+    this.logger(item.output ?? response.apps.id, response.apps.terminal.big);
   }
 }

--- a/src/commands/team/backup.ts
+++ b/src/commands/team/backup.ts
@@ -44,6 +44,6 @@ export default class extends Command {
 
     await workspace.fs.writeFile(backupZipUri, Buffer.from(await backup.arrayBuffer()));
 
-    window.showInformationMessage(t("backup.success", { dir: backupZipUri.fsPath }));
+    await window.showInformationMessage(t("backup.success", { dir: backupZipUri.fsPath }));
   }
 }

--- a/src/commands/team/backup.ts
+++ b/src/commands/team/backup.ts
@@ -18,7 +18,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
+  async run(task: TaskData, item: TeamAppTreeItem) {
     const workspaceAvailable = extension.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
     if (workspaceAvailable) workspaceFolder = await extension.getWorkspaceFolder();
@@ -27,22 +27,17 @@ export default class extends Command {
       if (!workspaceFolder) throw Error(t("no.folder.found"));
     }
 
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false, startInTeamApps: true });
-      item = picked.app;
-    }
+    const response = await extension.api.get<RESTGetApiAppBackupResult>(Routes.teamBackup(item.appId));
+    if (!response) return;
 
-    const res = await extension.api.get<RESTGetApiAppBackupResult>(Routes.teamBackup(item.appId));
-    if (!res) return;
+    if (!response.backups) throw Error(t("no.backup.found"));
 
-    if (!res.backups) throw Error(t("no.backup.found"));
-
-    const backup = await fetch(res.backups.url);
+    const backup = await fetch(response.backups.url);
     if (!backup.body) throw Error(t("backup.request.failed"));
 
     const configBackupDir = extension.config.get<string>(ConfigKeys.teamBackupDir) ?? "";
     const backupDirUri = workspaceAvailable ? Uri.joinPath(workspaceFolder, configBackupDir) : workspaceFolder;
-    const backupZipUri = Uri.joinPath(backupDirUri, `${res.backups.id}.zip`);
+    const backupZipUri = Uri.joinPath(backupDirUri, `${response.backups.id}.zip`);
 
     if (!existsSync(backupDirUri.fsPath))
       await workspace.fs.createDirectory(backupDirUri);

--- a/src/commands/team/commit.ts
+++ b/src/commands/team/commit.ts
@@ -18,14 +18,9 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
+  async run(task: TaskData, item: TeamAppTreeItem) {
     const workspaceFolder = await extension.getWorkspaceFolder();
     if (!workspaceFolder) throw Error(t("no.workspace.folder.found"));
-
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false, startInTeamApps: true });
-      item = picked.app;
-    }
 
     if (!await this.confirmAction())
       throw new CancellationError();
@@ -62,16 +57,15 @@ export default class extends Command {
 
     task.progress.report({ increment: -1, message: item.appId });
 
-    const res = await extension.api.put<RESTPutApiAppCommitResult>(Routes.teamCommit(item.appId), { files });
+    const response = await extension.api.put<RESTPutApiAppCommitResult>(Routes.teamCommit(item.appId), { files });
+    if (!response) return;
 
-    if (!res) return;
-
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.teamAppTree.fetch();
 
-      if (res.logs) this.logger(item.output ?? item.appId, res.logs);
+      if (response.logs) this.logger(item.output ?? item.appId, response.logs);
     }
   }
 }

--- a/src/commands/team/copy.id.ts
+++ b/src/commands/team/copy.id.ts
@@ -1,7 +1,6 @@
 import { t } from "@vscode/l10n";
 import { env, window } from "vscode";
 import { type TaskData } from "../../@types";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
@@ -12,14 +11,9 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item?: AppTreeItem | TeamAppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(null, { startInTeamApps: true });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: TeamAppTreeItem) {
     await env.clipboard.writeText(item.appId);
 
-    window.showInformationMessage(t("copied.team.appid"));
+    await window.showInformationMessage(t("copied.team.appid"));
   }
 }

--- a/src/commands/team/logs.ts
+++ b/src/commands/team/logs.ts
@@ -16,17 +16,12 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false, startInTeamApps: true });
-      item = picked.app;
-    }
+  async run(_: TaskData, item: TeamAppTreeItem) {
+    const response = await extension.api.get<RESTGetApiAppLogResult>(Routes.teamLogs(item.appId));
+    if (!response) return;
 
-    const res = await extension.api.get<RESTGetApiAppLogResult>(Routes.teamLogs(item.appId));
-    if (!res) return;
+    if (!response.apps || !response.apps.terminal.big) throw Error(t("no.log.found"));
 
-    if (!res.apps || !res.apps.terminal.big) throw Error(t("no.log.found"));
-
-    this.logger(item.output ?? res.apps.id, res.apps.terminal.big);
+    this.logger(item.output ?? response.apps.id, response.apps.terminal.big);
   }
 }

--- a/src/commands/team/ram.ts
+++ b/src/commands/team/ram.ts
@@ -18,12 +18,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false, startInTeamApps: true });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: TeamAppTreeItem) {
     const min = item.type === AppType.site ? 512 : 100;
 
     const ramMB = await InputBox.getInt({
@@ -37,11 +32,11 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTPutApiAppRamResult>(Routes.teamRam(item.appId), { body: { ramMB } });
-    if (!res) return;
+    const response = await extension.api.put<RESTPutApiAppRamResult>(Routes.teamRam(item.appId), { body: { ramMB } });
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.teamAppTree.fetch();
     }

--- a/src/commands/team/restart.ts
+++ b/src/commands/team/restart.ts
@@ -16,20 +16,15 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false, startInTeamApps: true });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: TeamAppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTPutApiAppRestartResult>(Routes.teamRestart(item.appId));
-    if (!res) return;
+    const response = await extension.api.put<RESTPutApiAppRestartResult>(Routes.teamRestart(item.appId));
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.teamAppTree.fetch();
     }

--- a/src/commands/team/start.ts
+++ b/src/commands/team/start.ts
@@ -16,17 +16,12 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false, startInTeamApps: true });
-      item = picked.app;
-    }
+  async run(_: TaskData, item: TeamAppTreeItem) {
+    const response = await extension.api.put<RESTPutApiAppStartResult>(Routes.teamStart(item.appId));
+    if (!response) return;
 
-    const res = await extension.api.put<RESTPutApiAppStartResult>(Routes.teamStart(item.appId));
-    if (!res) return;
-
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.teamAppTree.fetch();
     }

--- a/src/commands/team/status.ts
+++ b/src/commands/team/status.ts
@@ -15,11 +15,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
-    if (!item?.children.size) 
-      await extension.teamAppTree.fetch();
-
-    if (extension.teamAppTree.children.size)
-      await extension.teamAppTree.getStatus();
+  async run(_: TaskData, item: TeamAppTreeItem) {
+    await extension.teamAppTree.getStatus(item.appId);
   }
 }

--- a/src/commands/team/stop.ts
+++ b/src/commands/team/stop.ts
@@ -16,20 +16,15 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: TeamAppTreeItem) {
-    if (!item) {
-      const picked = await this.pickAppOrTeamApp(task, { showOther: false, startInTeamApps: true });
-      item = picked.app;
-    }
-
+  async run(_: TaskData, item: TeamAppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const res = await extension.api.put<RESTPutApiAppStartResult>(Routes.teamStop(item.appId));
-    if (!res) return;
+    const response = await extension.api.put<RESTPutApiAppStartResult>(Routes.teamStop(item.appId));
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
       await extension.teamAppTree.fetch();
     }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -68,20 +68,20 @@ export default class extends Command {
 
     task.progress.report({ increment: -1, message: t("uploading") });
 
-    const res = await extension.api.post<RESTPostApiUploadResult>(Routes.upload(), { files });
+    const response = await extension.api.post<RESTPostApiUploadResult>(Routes.upload(), { files });
 
-    if (!res) return;
+    if (!response) return;
 
-    if ("status" in res) {
-      this.showApiMessage(res);
+    if ("status" in response) {
+      this.showApiMessage(response);
 
-      if ("app" in res && res.app) {
-        dConfig.update({ ID: res.app.id, AVATAR: res.app.avatarURL });
+      if ("app" in response && response.app) {
+        dConfig.update({ ID: response.app.id, AVATAR: response.app.avatarURL });
         await extension.appTree.fetch();
       }
 
-      if (res.logs) {
-        this.logger("app" in res && res.app ? res.app.id : "Discloud Upload Error", res.logs);
+      if (response.logs) {
+        this.logger("app" in response && response.app ? response.app.id : "Discloud Upload Error", response.logs);
       }
     }
   }

--- a/src/events/rateLimited.ts
+++ b/src/events/rateLimited.ts
@@ -13,7 +13,7 @@ extension.on("rateLimited", async function (rateLimitData) {
 
   extension.logger.warn("Rate limited by " + time + " seconds");
 
-  window.showInformationMessage(t("ratelimited", { s: time }));
+  await window.showInformationMessage(t("ratelimited", { s: time }));
 
   extension.statusBar.setRateLimited(true);
 

--- a/src/events/teamAppUpdate.ts
+++ b/src/events/teamAppUpdate.ts
@@ -18,5 +18,5 @@ extension.on("teamAppUpdate", async function (oldApp, newApp) {
   }
 
   if (messageList.length)
-    window.showInformationMessage(messageList.join("\n"));
+    await window.showInformationMessage(messageList.join("\n"));
 });

--- a/src/providers/LanguageConfigurationProvider.ts
+++ b/src/providers/LanguageConfigurationProvider.ts
@@ -51,7 +51,7 @@ export default class LanguageConfigurationProvider extends BaseLanguageProvider 
     this.context.subscriptions.push(disposable);
   }
 
-  checkDocument(document: TextDocument) {
+  async checkDocument(document: TextDocument) {
     if (document.languageId !== this.schema.$id) return;
 
     const diagnostics: Diagnostic[] = [];
@@ -64,7 +64,7 @@ export default class LanguageConfigurationProvider extends BaseLanguageProvider 
         if (!document.uri._discloudDiscloudHasWrongLocationWarned) {
           // @ts-expect-error ts(2339)
           document.uri._discloudDiscloudHasWrongLocationWarned = true;
-          window.showErrorMessage(t("diagnostic.wrong.file.location"));
+          await window.showErrorMessage(t("diagnostic.wrong.file.location"));
         }
 
         diagnostics.push({

--- a/src/providers/TeamAppTreeDataProvider.ts
+++ b/src/providers/TeamAppTreeDataProvider.ts
@@ -1,5 +1,5 @@
 import { t } from "@vscode/l10n";
-import { type ApiStatusApp, type ApiTeamApps, type BaseApiApp, type RESTGetApiAppAllStatusResult, type RESTGetApiAppStatusResult, type RESTGetApiTeamResult, Routes } from "discloud.app";
+import { type ApiStatusApp, type ApiTeamApps, type BaseApiApp, type RESTGetApiAppStatusResult, type RESTGetApiTeamResult, Routes } from "discloud.app";
 import { type ExtensionContext, type ProviderResult, TreeItem, TreeItemCollapsibleState, commands, window } from "vscode";
 import extension from "../extension";
 import TeamAppTreeItem from "../structures/TeamAppTreeItem";
@@ -159,13 +159,13 @@ export default class TeamAppTreeDataProvider extends BaseTreeDataProvider<Item> 
   }
 
   async getApps() {
-    const res = await extension.api.get<RESTGetApiTeamResult>("/team");
+    const response = await extension.api.get<RESTGetApiTeamResult>("/team");
 
-    if (!res) return;
+    if (!response) return;
 
-    if (!res.apps) {
-      if ("statusCode" in res) {
-        switch (res.statusCode) {
+    if (!response.apps) {
+      if ("statusCode" in response) {
+        switch (response.statusCode) {
           case 403:
             this.init();
             break;
@@ -175,26 +175,19 @@ export default class TeamAppTreeDataProvider extends BaseTreeDataProvider<Item> 
       return;
     }
 
-    this.setRawApps(res.apps);
+    this.setRawApps(response.apps);
   }
 
-  async getStatus(appId: string = "all") {
-    const res = await extension.api.queueGet<
-      | RESTGetApiAppStatusResult
-      | RESTGetApiAppAllStatusResult
-    >(Routes.teamStatus(appId), {});
+  async getStatus(appId: string) {
+    const response = await extension.api.queueGet<RESTGetApiAppStatusResult>(Routes.teamStatus(appId));
 
-    if (!res) return;
+    if (!response) return;
 
-    if (!res.apps) {
-      if ("statusCode" in res) {
-        switch (res.statusCode) {
+    if (!response.apps) {
+      if ("statusCode" in response) {
+        switch (response.statusCode) {
           case 404:
-            if (appId === "all") {
-              this.children.dispose();
-            } else {
-              this.delete(appId);
-            }
+            this.delete(appId);
             break;
         }
       }
@@ -202,13 +195,7 @@ export default class TeamAppTreeDataProvider extends BaseTreeDataProvider<Item> 
       return;
     }
 
-    if (Array.isArray(res.apps)) {
-      for (const app of res.apps) {
-        this.editRawApp(app.id, app);
-      }
-    } else {
-      this.editRawApp(appId, res.apps);
-    }
+    this.editRawApp(appId, response.apps);
   }
 
   async fetch() {

--- a/src/structures/Command.ts
+++ b/src/structures/Command.ts
@@ -8,7 +8,7 @@ import type TeamAppTreeItem from "./TeamAppTreeItem";
 import type VSUser from "./VSUser";
 
 export interface CommandConstructor {
-  new (...args: any[]): Command
+  new(...args: any[]): Command
 }
 
 export default abstract class Command {
@@ -302,21 +302,11 @@ export default abstract class Command {
 
   showApiMessage(data: Data) {
     if ("status" in data) {
-      const status = t(`${data.status}`);
-
-      if (data.status === "ok") {
-        window.showInformationMessage(
-          `${status}`
-          + (typeof data.statusCode === "number" ? ` ${data.statusCode}` : "")
-          + (data.message ? `: ${data.message}` : ""),
-        );
-      } else {
-        window.showWarningMessage(
-          `${status}`
-          + (typeof data.statusCode === "number" ? ` ${data.statusCode}` : "")
-          + (data.message ? `: ${data.message}` : ""),
-        );
-      }
+      window.showWarningMessage(
+        t(`${data.status}`)
+        + (typeof data.statusCode === "number" ? ` ${data.statusCode}` : "")
+        + (data.message ? `: ${data.message}` : ""),
+      );
     }
   }
 }

--- a/src/structures/Command.ts
+++ b/src/structures/Command.ts
@@ -226,15 +226,15 @@ export default abstract class Command {
   async pickAppMod(appId: string, task?: TaskData | null) {
     task?.progress.report({ increment: -1, message: t("choose.mod") });
 
-    const res = await extension.api.queueGet<RESTGetApiAppTeamResult>(Routes.appTeam(appId), {});
-    if (!res?.team?.length) return;
+    const response = await extension.api.queueGet<RESTGetApiAppTeamResult>(Routes.appTeam(appId), {});
+    if (!response?.team?.length) return;
 
-    const mods = new Map(res.team.map(team => [team.modID, {
+    const mods = new Map(response.team.map(team => [team.modID, {
       id: team.modID,
       perms: new Set(team.perms),
     }]));
 
-    const options = res.team.map(team => <QuickPickItem>{
+    const options = response.team.map(team => <QuickPickItem>{
       label: team.modID,
       description: team.perms.join(", "),
     });

--- a/src/structures/VSUser.ts
+++ b/src/structures/VSUser.ts
@@ -19,12 +19,12 @@ export default class VSUser implements ApiVscodeUser {
   async fetch(isVS?: boolean) {
     const method = isVS ? "queueGet" : "get";
 
-    const res = await extension.api[method]<RESTGetApiVscode>("/vscode");
+    const response = await extension.api[method]<RESTGetApiVscode>("/vscode");
 
-    if (!res) return this;
+    if (!response) return this;
 
-    if ("user" in res) {
-      Object.assign(this, res.user);
+    if ("user" in response) {
+      Object.assign(this, response.user);
 
       extension.emit("vscode", this);
     }
@@ -33,14 +33,14 @@ export default class VSUser implements ApiVscodeUser {
   }
 
   async setLocale(locale: string) {
-    const res = await extension.api.put<RESTPutApiLocaleResult>(Routes.locale(locale));
-    if (!res) return null;
+    const response = await extension.api.put<RESTPutApiLocaleResult>(Routes.locale(locale));
+    if (!response) return null;
 
-    if ("locale" in res)
-      this.locale = res.locale;
+    if ("locale" in response)
+      this.locale = response.locale;
 
-    return "body" in res ?
-      <RESTPutApiLocaleResult>res.body :
-      res;
+    return "body" in response ?
+      <RESTPutApiLocaleResult>response.body :
+      response;
   }
 }


### PR DESCRIPTION
- Updated multiple command files to enforce required AppTreeItem and TeamAppTreeItem parameters in run methods.
- Replaced response variable names for consistency across commands.
- Ensured all API response checks are uniform, improving readability and maintainability.
- Removed unnecessary item picking logic, streamlining command execution.