### PR TITLE
refactor: update command classes to use ExtensionCore instance

### DIFF
--- a/src/commands/apps/copy.id.ts
+++ b/src/commands/apps/copy.id.ts
@@ -1,11 +1,12 @@
 import { t } from "@vscode/l10n";
 import { env, window } from "vscode";
 import { type TaskData } from "../../@types";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTDeleteApiAppDeleteResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,14 +20,14 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.delete<RESTDeleteApiAppDeleteResult>(Routes.appDelete(item.appId));
+    const response = await this.core.api.delete<RESTDeleteApiAppDeleteResult>(Routes.appDelete(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
       if (response.status === "ok") {
-        core.appTree.delete(item.appId);
+        this.core.appTree.delete(item.appId);
       }
     }
   }

--- a/src/commands/apps/import.ts
+++ b/src/commands/apps/import.ts
@@ -4,13 +4,13 @@ import { type RESTGetApiAppBackupResult, Routes } from "discloud.app";
 import { existsSync } from "fs";
 import { ProgressLocation, Uri, commands, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 import { ConfigKeys } from "../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,15 +20,15 @@ export default class extends Command {
   }
 
   async run(task: TaskData, item: AppTreeItem) {
-    const workspaceAvailable = core.workspaceAvailable;
+    const workspaceAvailable = this.core.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
-    if (workspaceAvailable) workspaceFolder = await core.getWorkspaceFolder();
+    if (workspaceAvailable) workspaceFolder = await this.core.getWorkspaceFolder();
     if (!workspaceFolder) {
-      workspaceFolder = await core.getFolderDialog(task);
+      workspaceFolder = await this.core.getFolderDialog(task);
       if (!workspaceFolder) throw Error(t("no.folder.found"));
     }
 
-    const response = await core.api.get<RESTGetApiAppBackupResult>(Routes.appBackup(item.appId));
+    const response = await this.core.api.get<RESTGetApiAppBackupResult>(Routes.appBackup(item.appId));
     if (!response) return;
 
     if (!response.backups) throw Error(t("no.backup.found"));
@@ -36,7 +36,7 @@ export default class extends Command {
     const backup = await fetch(response.backups.url);
     if (!backup.body) throw Error(t("backup.request.failed"));
 
-    const configImportDir = core.config.get<string>(ConfigKeys.appImportDir) ?? "";
+    const configImportDir = this.core.config.get<string>(ConfigKeys.appImportDir) ?? "";
     const importDirUri = workspaceAvailable ? Uri.joinPath(workspaceFolder, configImportDir) : workspaceFolder;
     const importUri = Uri.joinPath(importDirUri, response.backups.id);
     const importZipUri = Uri.joinPath(importDirUri, `${response.backups.id}.zip`);

--- a/src/commands/apps/logs.ts
+++ b/src/commands/apps/logs.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTGetApiAppLogResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -17,7 +17,7 @@ export default class extends Command {
   }
 
   async run(_: TaskData, item: AppTreeItem) {
-    const response = await core.api.get<RESTGetApiAppLogResult>(Routes.appLogs(item.appId));
+    const response = await this.core.api.get<RESTGetApiAppLogResult>(Routes.appLogs(item.appId));
     if (!response) return;
 
     if (!response.apps || !response.apps.terminal.big) throw Error(t("no.log.found"));

--- a/src/commands/apps/mods/add.ts
+++ b/src/commands/apps/mods/add.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { ModPermissionsBF, type RESTPostApiAppTeamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation, type QuickPickItem, window } from "vscode";
 import { type TaskData } from "../../../@types";
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -35,7 +35,7 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.post<RESTPostApiAppTeamResult>(Routes.appTeam(item.appId), {
+    const response = await this.core.api.post<RESTPostApiAppTeamResult>(Routes.appTeam(item.appId), {
       body: {
         modID,
         perms,

--- a/src/commands/apps/mods/edit.ts
+++ b/src/commands/apps/mods/edit.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { ModPermissionsBF, type RESTPutApiAppTeamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation, type QuickPickItem, window } from "vscode";
 import { type TaskData } from "../../../@types";
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -34,7 +34,7 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTPutApiAppTeamResult>(Routes.appTeam(item.appId), {
+    const response = await this.core.api.put<RESTPutApiAppTeamResult>(Routes.appTeam(item.appId), {
       body: {
         modID: mod.id,
         perms,

--- a/src/commands/apps/mods/rem.ts
+++ b/src/commands/apps/mods/rem.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTDeleteApiAppTeamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../../@types";
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -23,7 +23,7 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.delete<RESTDeleteApiAppTeamResult>(Routes.appTeam(item.appId, mod.id));
+    const response = await this.core.api.delete<RESTDeleteApiAppTeamResult>(Routes.appTeam(item.appId, mod.id));
     if (!response) return;
 
     if ("status" in response) {

--- a/src/commands/apps/profile/avatar.ts
+++ b/src/commands/apps/profile/avatar.ts
@@ -2,13 +2,13 @@ import { t } from "@vscode/l10n";
 import { type BaseApiApp, DiscloudConfig, DiscloudConfigScopes, type RESTApiBaseResult, Routes } from "discloud.app";
 import { CancellationError } from "vscode";
 import { type TaskData } from "../../../@types";
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
 import InputBox from "../../../utils/Input";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
@@ -21,16 +21,16 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { avatarURL } });
+    const response = await this.core.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { avatarURL } });
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
       if (response.status === "ok") {
-        core.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, avatarURL });
+        this.core.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, avatarURL });
 
-        const workspaceFolder = await core.getWorkspaceFolder({ fallbackUserChoice: false });
+        const workspaceFolder = await this.core.getWorkspaceFolder({ fallbackUserChoice: false });
 
         if (workspaceFolder) {
           const dConfig = await DiscloudConfig.fromPath(workspaceFolder.fsPath);

--- a/src/commands/apps/profile/name.ts
+++ b/src/commands/apps/profile/name.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type BaseApiApp, DiscloudConfig, DiscloudConfigScopes, type RESTApiBaseResult, Routes } from "discloud.app";
 import { CancellationError, window } from "vscode";
 import { type TaskData } from "../../../@types";
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
@@ -25,16 +25,16 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { name } });
+    const response = await this.core.api.put<RESTApiBaseResult>(Routes.appProfile(item.appId), { body: { name } });
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
       if (response.status === "ok") {
-        core.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, name });
+        this.core.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, name });
 
-        const workspaceFolder = await core.getWorkspaceFolder({ fallbackUserChoice: false });
+        const workspaceFolder = await this.core.getWorkspaceFolder({ fallbackUserChoice: false });
 
         if (workspaceFolder) {
           const dConfig = await DiscloudConfig.fromPath(workspaceFolder.fsPath);

--- a/src/commands/apps/refresh.ts
+++ b/src/commands/apps/refresh.ts
@@ -1,12 +1,12 @@
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
   async run() {
-    await core.appTree.fetch();
+    await this.core.appTree.fetch();
   }
 }

--- a/src/commands/apps/restart.ts
+++ b/src/commands/apps/restart.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppRestartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,13 +20,13 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTPutApiAppRestartResult>(Routes.appRestart(item.appId));
+    const response = await this.core.api.put<RESTPutApiAppRestartResult>(Routes.appRestart(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.appTree.fetch();
+      await this.core.appTree.fetch();
     }
   }
 }

--- a/src/commands/apps/show.avatar.instead.status/always.ts
+++ b/src/commands/apps/show.avatar.instead.status/always.ts
@@ -1,9 +1,9 @@
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import Command from "../../../structures/Command";
 import { ConfigKeys } from "../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appShowAvatarInsteadStatus;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "always", isGlobal);
+    this.core.config.update(configKey, "always", isGlobal);
   }
 }

--- a/src/commands/apps/show.avatar.instead.status/never.ts
+++ b/src/commands/apps/show.avatar.instead.status/never.ts
@@ -1,9 +1,9 @@
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import Command from "../../../structures/Command";
 import { ConfigKeys } from "../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appShowAvatarInsteadStatus;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "never", isGlobal);
+    this.core.config.update(configKey, "never", isGlobal);
   }
 }

--- a/src/commands/apps/show.avatar.instead.status/when.online.ts
+++ b/src/commands/apps/show.avatar.instead.status/when.online.ts
@@ -1,9 +1,9 @@
-import core from "../../../extension";
+import type ExtensionCore from "../../../core/extension";
 import Command from "../../../structures/Command";
 import { ConfigKeys } from "../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appShowAvatarInsteadStatus;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "when.online", isGlobal);
+    this.core.config.update(configKey, "when.online", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/id.asc.ts
+++ b/src/commands/apps/sort/by/id.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "id.asc", isGlobal);
+    this.core.config.update(configKey, "id.asc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/id.desc.ts
+++ b/src/commands/apps/sort/by/id.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "id.desc", isGlobal);
+    this.core.config.update(configKey, "id.desc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/memory.usage.asc.ts
+++ b/src/commands/apps/sort/by/memory.usage.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "memory.usage.asc", isGlobal);
+    this.core.config.update(configKey, "memory.usage.asc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/memory.usage.desc.ts
+++ b/src/commands/apps/sort/by/memory.usage.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "memory.usage.desc", isGlobal);
+    this.core.config.update(configKey, "memory.usage.desc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/name.asc.ts
+++ b/src/commands/apps/sort/by/name.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "name.asc", isGlobal);
+    this.core.config.update(configKey, "name.asc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/name.desc.ts
+++ b/src/commands/apps/sort/by/name.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "name.desc", isGlobal);
+    this.core.config.update(configKey, "name.desc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/none.ts
+++ b/src/commands/apps/sort/by/none.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "none", isGlobal);
+    this.core.config.update(configKey, "none", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/started.asc.ts
+++ b/src/commands/apps/sort/by/started.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "started.asc", isGlobal);
+    this.core.config.update(configKey, "started.asc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/by/started.desc.ts
+++ b/src/commands/apps/sort/by/started.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "started.desc", isGlobal);
+    this.core.config.update(configKey, "started.desc", isGlobal);
   }
 }

--- a/src/commands/apps/sort/online/activate.ts
+++ b/src/commands/apps/sort/online/activate.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortOnline;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, true, isGlobal);
+    this.core.config.update(configKey, true, isGlobal);
   }
 }

--- a/src/commands/apps/sort/online/deactivate.ts
+++ b/src/commands/apps/sort/online/deactivate.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.appSortOnline;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, false, isGlobal);
+    this.core.config.update(configKey, false, isGlobal);
   }
 }

--- a/src/commands/apps/start.ts
+++ b/src/commands/apps/start.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -17,13 +17,13 @@ export default class extends Command {
   }
 
   async run(_: TaskData, item: AppTreeItem) {
-    const response = await core.api.put<RESTPutApiAppStartResult>(Routes.appStart(item.appId));
+    const response = await this.core.api.put<RESTPutApiAppStartResult>(Routes.appStart(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.appTree.fetch();
+      await this.core.appTree.fetch();
     }
   }
 }

--- a/src/commands/apps/status.ts
+++ b/src/commands/apps/status.ts
@@ -1,12 +1,12 @@
 import { t } from "@vscode/l10n";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -16,6 +16,6 @@ export default class extends Command {
   }
 
   async run(_: TaskData, item: AppTreeItem) {
-    await core.appTree.getStatus(item.appId);
+    await this.core.appTree.getStatus(item.appId);
   }
 }

--- a/src/commands/apps/stop.ts
+++ b/src/commands/apps/stop.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,13 +20,13 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTPutApiAppStartResult>(Routes.appStop(item.appId));
+    const response = await this.core.api.put<RESTPutApiAppStartResult>(Routes.appStop(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.appTree.fetch();
+      await this.core.appTree.fetch();
     }
   }
 }

--- a/src/commands/apps/terminal.ts
+++ b/src/commands/apps/terminal.ts
@@ -1,22 +1,22 @@
 import { type Uri, window } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
   async run(_: TaskData, item: AppTreeItem) {
     const terminal = window.createTerminal({
-      env: { DISCLOUD_TOKEN: await core.secrets.getToken() },
+      env: { DISCLOUD_TOKEN: await this.core.secrets.getToken() },
       iconPath: item.iconPath as Uri,
       name: typeof item.label === "string" ? item.label : item.appId,
     });
 
-    core.context.subscriptions.push(terminal);
+    this.core.context.subscriptions.push(terminal);
 
     terminal.show();
 

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -2,7 +2,7 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppCommitResult, Routes, resolveFile } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../@types";
-import core from "../extension";
+import type ExtensionCore from "../core/extension";
 import { socketCommit } from "../services/discloud/socket/actions/commit";
 import AppTreeItem from "../structures/AppTreeItem";
 import Command from "../structures/Command";
@@ -13,7 +13,7 @@ import { pickApp } from "../utils/apps";
 import { ApiActionsStrategy, ConfigKeys } from "../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -23,7 +23,7 @@ export default class extends Command {
   }
 
   async run(task: TaskData) {
-    const workspaceFolder = await core.getWorkspaceFolder({ token: task.token });
+    const workspaceFolder = await this.core.getWorkspaceFolder({ token: task.token });
     if (!workspaceFolder) throw Error(t("no.workspace.folder.found"));
 
     const fileNames = await FileSystem.readSelectedPath(true);
@@ -31,7 +31,7 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    core.statusBar.setCommitting();
+    this.core.statusBar.setCommitting();
 
     const item = await pickApp({ token: task.token });
     if (!item) throw Error(t("missing.appid"));
@@ -42,7 +42,7 @@ export default class extends Command {
       cwd: workspaceFolder.fsPath,
       fileNames,
       ignoreFile: ".discloudignore",
-      ignoreList: core.workspaceIgnoreList,
+      ignoreList: this.core.workspaceIgnoreList,
     });
 
     const found = await fs.findFiles(task.token);
@@ -56,7 +56,7 @@ export default class extends Command {
 
     const buffer = await zipper.getBuffer();
 
-    const strategy = core.config.get(ConfigKeys.apiActionsStrategy, ApiActionsStrategy.socket);
+    const strategy = this.core.config.get(ConfigKeys.apiActionsStrategy, ApiActionsStrategy.socket);
 
     await this[strategy](task, buffer, item);
   }
@@ -70,7 +70,7 @@ export default class extends Command {
 
     const isUserApp = app instanceof AppTreeItem;
 
-    const response = await core.api.put<RESTPutApiAppCommitResult>(
+    const response = await this.core.api.put<RESTPutApiAppCommitResult>(
       isUserApp ? Routes.appCommit(app.appId) : Routes.teamCommit(app.appId),
       { files },
     );
@@ -80,9 +80,9 @@ export default class extends Command {
       this.showApiMessage(response);
 
       if (isUserApp)
-        await core.appTree.fetch();
+        await this.core.appTree.fetch();
       else
-        await core.teamAppTree.fetch();
+        await this.core.teamAppTree.fetch();
 
       if (response.logs) this.logger(app.output ?? app.appId, response.logs);
     }

--- a/src/commands/create.config.ts
+++ b/src/commands/create.config.ts
@@ -1,19 +1,19 @@
 import { t } from "@vscode/l10n";
 import { DiscloudConfig } from "discloud.app";
 import { Uri, workspace } from "vscode";
+import type ExtensionCore from "../core/extension";
 import WarningError from "../errors/warning";
-import core from "../extension";
 import Command from "../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
   }
 
   async run() {
-    const workspaceFolder = await core.getWorkspaceFolder({ fallbackUserChoice: false });
+    const workspaceFolder = await this.core.getWorkspaceFolder({ fallbackUserChoice: false });
     if (!workspaceFolder) throw Error(t("no.workspace.folder.found"));
 
     const findConfig = await workspace.findFiles(DiscloudConfig.filename);

--- a/src/commands/domain/refresh.ts
+++ b/src/commands/domain/refresh.ts
@@ -1,12 +1,12 @@
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
   async run() {
-    await core.appTree.fetch();
+    await this.core.appTree.fetch();
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -1,11 +1,11 @@
 import { t } from "@vscode/l10n";
 import { window } from "vscode";
-import core from "../extension";
+import type ExtensionCore from "../core/extension";
 import { tokenIsDiscloudJwt, tokenValidator } from "../services/discloud/utils";
 import Command from "../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -29,7 +29,7 @@ export default class extends Command {
 
     if (!authorization) throw Error(t("invalid.token"));
 
-    await core.secrets.setToken(input);
+    await this.core.secrets.setToken(input);
 
     void window.showInformationMessage(t("valid.token"));
   }

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,18 +1,18 @@
-import core from "../extension";
+import type ExtensionCore from "../core/extension";
 import Command from "../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
   }
 
   async run() {
-    if (!await core.secrets.getToken()) return;
+    if (!await this.core.secrets.getToken()) return;
 
-    await core.secrets.setToken();
+    await this.core.secrets.setToken();
 
-    core.emit("missingToken");
+    this.core.emit("missingToken");
   }
 }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -2,14 +2,14 @@ import { t } from "@vscode/l10n";
 import { DiscloudConfig, DiscloudConfigScopes, type RESTGetApiAppLogResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../@types";
-import core from "../extension";
+import type ExtensionCore from "../core/extension";
 import AppTreeItem from "../structures/AppTreeItem";
 import Command from "../structures/Command";
 import type TeamAppTreeItem from "../structures/TeamAppTreeItem";
 import { pickApp } from "../utils/apps";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,13 +20,13 @@ export default class extends Command {
 
   async run(task: TaskData, item?: AppTreeItem | TeamAppTreeItem) {
     if (!item) {
-      const workspaceFolder = await core.getWorkspaceFolder({ fallbackUserChoice: false });
+      const workspaceFolder = await this.core.getWorkspaceFolder({ fallbackUserChoice: false });
       if (workspaceFolder) {
         const dConfig = await DiscloudConfig.fromPath(workspaceFolder.fsPath);
 
         const ID = dConfig.get(DiscloudConfigScopes.ID);
 
-        if (ID) item = core.appTree.children.get(ID) ?? core.teamAppTree.children.get(ID)!;
+        if (ID) item = this.core.appTree.children.get(ID) ?? this.core.teamAppTree.children.get(ID)!;
 
         if (!item) throw Error(t("missing.appid"));
       } else {
@@ -38,7 +38,7 @@ export default class extends Command {
       }
     }
 
-    const response = await core.api.get<RESTGetApiAppLogResult>(
+    const response = await this.core.api.get<RESTGetApiAppLogResult>(
       item instanceof AppTreeItem
         ? Routes.appLogs(item.appId)
         : Routes.teamLogs(item.appId),

--- a/src/commands/subdomain/refresh.ts
+++ b/src/commands/subdomain/refresh.ts
@@ -1,12 +1,12 @@
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
   async run() {
-    await core.appTree.fetch();
+    await this.core.appTree.fetch();
   }
 }

--- a/src/commands/team/backup.ts
+++ b/src/commands/team/backup.ts
@@ -3,13 +3,13 @@ import { type RESTGetApiAppBackupResult, Routes } from "discloud.app";
 import { existsSync } from "fs";
 import { ProgressLocation, Uri, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 import { ConfigKeys } from "../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -19,15 +19,15 @@ export default class extends Command {
   }
 
   async run(task: TaskData, item: TeamAppTreeItem) {
-    const workspaceAvailable = core.workspaceAvailable;
+    const workspaceAvailable = this.core.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
-    if (workspaceAvailable) workspaceFolder = await core.getWorkspaceFolder();
+    if (workspaceAvailable) workspaceFolder = await this.core.getWorkspaceFolder();
     if (!workspaceFolder) {
-      workspaceFolder = await core.getFolderDialog(task);
+      workspaceFolder = await this.core.getFolderDialog(task);
       if (!workspaceFolder) throw Error(t("no.folder.found"));
     }
 
-    const response = await core.api.get<RESTGetApiAppBackupResult>(Routes.teamBackup(item.appId));
+    const response = await this.core.api.get<RESTGetApiAppBackupResult>(Routes.teamBackup(item.appId));
     if (!response) return;
 
     if (!response.backups) throw Error(t("no.backup.found"));
@@ -35,7 +35,7 @@ export default class extends Command {
     const backup = await fetch(response.backups.url);
     if (!backup.body) throw Error(t("backup.request.failed"));
 
-    const configBackupDir = core.config.get<string>(ConfigKeys.teamBackupDir) ?? "";
+    const configBackupDir = this.core.config.get<string>(ConfigKeys.teamBackupDir) ?? "";
     const backupDirUri = workspaceAvailable ? Uri.joinPath(workspaceFolder, configBackupDir) : workspaceFolder;
     const backupZipUri = Uri.joinPath(backupDirUri, `${response.backups.id}.zip`);
 

--- a/src/commands/team/commit.ts
+++ b/src/commands/team/commit.ts
@@ -2,7 +2,7 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppCommitResult, Routes, resolveFile } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import { socketCommit } from "../../services/discloud/socket/actions/commit";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
@@ -11,7 +11,7 @@ import Zip from "../../utils/Zip";
 import { ApiActionsStrategy, ConfigKeys } from "../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -21,20 +21,20 @@ export default class extends Command {
   }
 
   async run(task: TaskData, item: TeamAppTreeItem) {
-    const workspaceFolder = await core.getWorkspaceFolder({ token: task.token });
+    const workspaceFolder = await this.core.getWorkspaceFolder({ token: task.token });
     if (!workspaceFolder) throw Error(t("no.workspace.folder.found"));
 
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    core.statusBar.setCommitting();
+    this.core.statusBar.setCommitting();
 
     task.progress.report({ increment: 30, message: `${item.appId} - ${t("choose.files")}` });
 
     const fs = new FileSystem({
       cwd: workspaceFolder.fsPath,
       ignoreFile: ".discloudignore",
-      ignoreList: core.workspaceIgnoreList,
+      ignoreList: this.core.workspaceIgnoreList,
     });
 
     const found = await fs.findFiles(false);
@@ -48,7 +48,7 @@ export default class extends Command {
 
     const buffer = await zipper.getBuffer();
 
-    const strategy = core.config.get(ConfigKeys.apiActionsStrategy, ApiActionsStrategy.socket);
+    const strategy = this.core.config.get(ConfigKeys.apiActionsStrategy, ApiActionsStrategy.socket);
 
     await this[strategy](task, buffer, item);
   }
@@ -60,13 +60,13 @@ export default class extends Command {
 
     const files: File[] = [file];
 
-    const response = await core.api.put<RESTPutApiAppCommitResult>(Routes.teamCommit(app.appId), { files });
+    const response = await this.core.api.put<RESTPutApiAppCommitResult>(Routes.teamCommit(app.appId), { files });
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.teamAppTree.fetch();
+      await this.core.teamAppTree.fetch();
 
       if (response.logs) this.logger(app.output ?? app.appId, response.logs);
     }

--- a/src/commands/team/copy.id.ts
+++ b/src/commands/team/copy.id.ts
@@ -1,11 +1,12 @@
 import { t } from "@vscode/l10n";
 import { env, window } from "vscode";
 import { type TaskData } from "../../@types";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });

--- a/src/commands/team/import.ts
+++ b/src/commands/team/import.ts
@@ -4,13 +4,13 @@ import { type RESTGetApiAppBackupResult, Routes } from "discloud.app";
 import { existsSync } from "fs";
 import { ProgressLocation, Uri, commands, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 import { ConfigKeys } from "../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,15 +20,15 @@ export default class extends Command {
   }
 
   async run(task: TaskData, item: TeamAppTreeItem) {
-    const workspaceAvailable = core.workspaceAvailable;
+    const workspaceAvailable = this.core.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
-    if (workspaceAvailable) workspaceFolder = await core.getWorkspaceFolder();
+    if (workspaceAvailable) workspaceFolder = await this.core.getWorkspaceFolder();
     if (!workspaceFolder) {
-      workspaceFolder = await core.getFolderDialog(task);
+      workspaceFolder = await this.core.getFolderDialog(task);
       if (!workspaceFolder) throw Error(t("no.folder.found"));
     }
 
-    const response = await core.api.get<RESTGetApiAppBackupResult>(Routes.teamBackup(item.appId));
+    const response = await this.core.api.get<RESTGetApiAppBackupResult>(Routes.teamBackup(item.appId));
     if (!response) return;
 
     if (!response.backups) throw Error(t("no.backup.found"));
@@ -36,7 +36,7 @@ export default class extends Command {
     const backup = await fetch(response.backups.url);
     if (!backup.body) throw Error(t("backup.request.failed"));
 
-    const configImportDir = core.config.get<string>(ConfigKeys.teamImportDir) ?? "";
+    const configImportDir = this.core.config.get<string>(ConfigKeys.teamImportDir) ?? "";
     const importDirUri = workspaceAvailable ? Uri.joinPath(workspaceFolder, configImportDir) : workspaceFolder;
     const importUri = Uri.joinPath(importDirUri, response.backups.id);
     const importZipUri = Uri.joinPath(importDirUri, `${response.backups.id}.zip`);

--- a/src/commands/team/logs.ts
+++ b/src/commands/team/logs.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTGetApiAppLogResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -17,7 +17,7 @@ export default class extends Command {
   }
 
   async run(_: TaskData, item: TeamAppTreeItem) {
-    const response = await core.api.get<RESTGetApiAppLogResult>(Routes.teamLogs(item.appId));
+    const response = await this.core.api.get<RESTGetApiAppLogResult>(Routes.teamLogs(item.appId));
     if (!response) return;
 
     if (!response.apps || !response.apps.terminal.big) throw Error(t("no.log.found"));

--- a/src/commands/team/ram.ts
+++ b/src/commands/team/ram.ts
@@ -3,13 +3,13 @@ import { type RESTPutApiAppRamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { AppType } from "../../@enum";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 import InputBox from "../../utils/Input";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -32,13 +32,13 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTPutApiAppRamResult>(Routes.teamRam(item.appId), { body: { ramMB } });
+    const response = await this.core.api.put<RESTPutApiAppRamResult>(Routes.teamRam(item.appId), { body: { ramMB } });
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.teamAppTree.fetch();
+      await this.core.teamAppTree.fetch();
     }
   }
 }

--- a/src/commands/team/refresh.ts
+++ b/src/commands/team/refresh.ts
@@ -1,12 +1,12 @@
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
   async run() {
-    await core.teamAppTree.fetch();
+    await this.core.teamAppTree.fetch();
   }
 }

--- a/src/commands/team/restart.ts
+++ b/src/commands/team/restart.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppRestartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,13 +20,13 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTPutApiAppRestartResult>(Routes.teamRestart(item.appId));
+    const response = await this.core.api.put<RESTPutApiAppRestartResult>(Routes.teamRestart(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.teamAppTree.fetch();
+      await this.core.teamAppTree.fetch();
     }
   }
 }

--- a/src/commands/team/sort/by/id.asc.ts
+++ b/src/commands/team/sort/by/id.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "id.asc", isGlobal);
+    this.core.config.update(configKey, "id.asc", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/id.desc.ts
+++ b/src/commands/team/sort/by/id.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "id.desc", isGlobal);
+    this.core.config.update(configKey, "id.desc", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/memory.usage.asc.ts
+++ b/src/commands/team/sort/by/memory.usage.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "memory.usage.asc", isGlobal);
+    this.core.config.update(configKey, "memory.usage.asc", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/memory.usage.desc.ts
+++ b/src/commands/team/sort/by/memory.usage.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "memory.usage.desc", isGlobal);
+    this.core.config.update(configKey, "memory.usage.desc", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/name.asc.ts
+++ b/src/commands/team/sort/by/name.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "name.asc", isGlobal);
+    this.core.config.update(configKey, "name.asc", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/name.desc.ts
+++ b/src/commands/team/sort/by/name.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "name.desc", isGlobal);
+    this.core.config.update(configKey, "name.desc", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/none.ts
+++ b/src/commands/team/sort/by/none.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "none", isGlobal);
+    this.core.config.update(configKey, "none", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/started.asc.ts
+++ b/src/commands/team/sort/by/started.asc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "started.asc", isGlobal);
+    this.core.config.update(configKey, "started.asc", isGlobal);
   }
 }

--- a/src/commands/team/sort/by/started.desc.ts
+++ b/src/commands/team/sort/by/started.desc.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortBy;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, "started.desc", isGlobal);
+    this.core.config.update(configKey, "started.desc", isGlobal);
   }
 }

--- a/src/commands/team/sort/online/activate.ts
+++ b/src/commands/team/sort/online/activate.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortOnline;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, true, isGlobal);
+    this.core.config.update(configKey, true, isGlobal);
   }
 }

--- a/src/commands/team/sort/online/deactivate.ts
+++ b/src/commands/team/sort/online/deactivate.ts
@@ -1,9 +1,9 @@
-import core from "../../../../extension";
+import type ExtensionCore from "../../../../core/extension";
 import Command from "../../../../structures/Command";
 import { ConfigKeys } from "../../../../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       allowTokenless: true,
     });
@@ -12,10 +12,10 @@ export default class extends Command {
   async run() {
     const configKey = ConfigKeys.teamSortOnline;
 
-    const inspect = core.config.inspect<number>(configKey);
+    const inspect = this.core.config.inspect<number>(configKey);
 
     const isGlobal = !inspect?.workspaceValue;
 
-    core.config.update(configKey, false, isGlobal);
+    this.core.config.update(configKey, false, isGlobal);
   }
 }

--- a/src/commands/team/start.ts
+++ b/src/commands/team/start.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -17,13 +17,13 @@ export default class extends Command {
   }
 
   async run(_: TaskData, item: TeamAppTreeItem) {
-    const response = await core.api.put<RESTPutApiAppStartResult>(Routes.teamStart(item.appId));
+    const response = await this.core.api.put<RESTPutApiAppStartResult>(Routes.teamStart(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.teamAppTree.fetch();
+      await this.core.teamAppTree.fetch();
     }
   }
 }

--- a/src/commands/team/status.ts
+++ b/src/commands/team/status.ts
@@ -1,12 +1,12 @@
 import { t } from "@vscode/l10n";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -16,6 +16,6 @@ export default class extends Command {
   }
 
   async run(_: TaskData, item: TeamAppTreeItem) {
-    await core.teamAppTree.getStatus(item.appId);
+    await this.core.teamAppTree.getStatus(item.appId);
   }
 }

--- a/src/commands/team/stop.ts
+++ b/src/commands/team/stop.ts
@@ -2,12 +2,12 @@ import { t } from "@vscode/l10n";
 import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import Command from "../../structures/Command";
 import type TeamAppTreeItem from "../../structures/TeamAppTreeItem";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,13 +20,13 @@ export default class extends Command {
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    const response = await core.api.put<RESTPutApiAppStartResult>(Routes.teamStop(item.appId));
+    const response = await this.core.api.put<RESTPutApiAppStartResult>(Routes.teamStop(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await core.teamAppTree.fetch();
+      await this.core.teamAppTree.fetch();
     }
   }
 }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -2,7 +2,7 @@ import { t } from "@vscode/l10n";
 import { DiscloudConfig, resolveFile, type RESTPostApiUploadResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation, Uri } from "vscode";
 import { type TaskData } from "../@types";
-import core from "../extension";
+import type ExtensionCore from "../core/extension";
 import { socketUpload } from "../services/discloud/socket/actions/upload";
 import Command from "../structures/Command";
 import FileSystem from "../utils/FileSystem";
@@ -10,7 +10,7 @@ import Zip from "../utils/Zip";
 import { ApiActionsStrategy, ConfigKeys } from "../utils/constants";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super({
       progress: {
         location: ProgressLocation.Notification,
@@ -20,13 +20,13 @@ export default class extends Command {
   }
 
   async run(task: TaskData) {
-    const workspaceFolder = await core.getWorkspaceFolder({ token: task.token });
+    const workspaceFolder = await this.core.getWorkspaceFolder({ token: task.token });
     if (!workspaceFolder) throw Error(t("no.workspace.folder.found"));
 
     if (!await this.confirmAction())
       throw new CancellationError();
 
-    core.statusBar.setUploading();
+    this.core.statusBar.setUploading();
 
     task.progress.report({ increment: 30, message: t("files.checking") });
 
@@ -38,7 +38,7 @@ export default class extends Command {
     const fs = new FileSystem({
       cwd: workspaceFolder.fsPath,
       ignoreFile: ".discloudignore",
-      ignoreList: core.workspaceIgnoreList,
+      ignoreList: this.core.workspaceIgnoreList,
     });
 
     const found = await fs.findFiles(task.token);
@@ -60,7 +60,7 @@ export default class extends Command {
 
     const buffer = await zipper.getBuffer();
 
-    const strategy = core.config.get(ConfigKeys.apiActionsStrategy, ApiActionsStrategy.socket);
+    const strategy = this.core.config.get(ConfigKeys.apiActionsStrategy, ApiActionsStrategy.socket);
 
     await this[strategy](task, buffer, dConfig);
   }
@@ -72,7 +72,7 @@ export default class extends Command {
 
     const files: File[] = [file];
 
-    const response = await core.api.post<RESTPostApiUploadResult>(Routes.upload(), { files });
+    const response = await this.core.api.post<RESTPostApiUploadResult>(Routes.upload(), { files });
 
     if (!response) return;
 
@@ -81,7 +81,7 @@ export default class extends Command {
 
       if ("app" in response && response.app) {
         dConfig.update({ ID: response.app.id, AVATAR: response.app.avatarURL });
-        await core.appTree.fetch();
+        await this.core.appTree.fetch();
       }
 
       if (response.logs) {

--- a/src/commands/user/set.locale.ts
+++ b/src/commands/user/set.locale.ts
@@ -1,12 +1,12 @@
 import { t } from "@vscode/l10n";
 import { CancellationError, commands, window } from "vscode";
 import { type TaskData } from "../../@types";
-import core from "../../extension";
+import type ExtensionCore from "../../core/extension";
 import DiscloudAPIError from "../../services/discloud/errors/api";
 import Command from "../../structures/Command";
 
 export default class extends Command {
-  constructor() {
+  constructor(readonly core: ExtensionCore) {
     super();
   }
 
@@ -33,7 +33,7 @@ export default class extends Command {
       throw new CancellationError();
 
     try {
-      const response = await core.user.setLocale(locale);
+      const response = await this.core.user.setLocale(locale);
       if (!response) return;
 
       if (response.status === "ok")


### PR DESCRIPTION
- Refactored multiple command classes to replace direct core imports with an instance of ExtensionCore passed through the constructor.
- Updated API calls and method invocations to use `this.core` instead of the global `core` reference.
- Improved code consistency and maintainability by ensuring all commands utilize the same core instance.