### PR TITLE
refactor: replace AppTreeItem with UserAppTreeItem across commands and services

### DIFF
--- a/src/@types/structures.ts
+++ b/src/@types/structures.ts
@@ -1,7 +1,7 @@
 import type { CancellationToken, ExtensionContext, LogOutputChannel, ProgressOptions, StatusBarItem, TreeItem, Uri, window } from "vscode";
-import type AppTreeItem from "../structures/AppTreeItem";
 import type BaseChildTreeItem from "../structures/BaseChildTreeItem";
 import type TeamAppTreeItem from "../structures/TeamAppTreeItem";
+import type UserAppTreeItem from "../structures/UserAppTreeItem";
 import type VSUser from "../structures/VSUser";
 import type { RateLimitData } from "./rest";
 
@@ -47,7 +47,7 @@ export interface BaseChildTreeItemData extends Omit<TreeItem, "id"> {
   label: NonNullable<TreeItem["label"]>
 }
 
-export interface AppChildTreeItemData extends BaseChildTreeItemData {
+export interface UserAppChildTreeItemData extends BaseChildTreeItemData {
   appId: string
   appType: number
   online: boolean
@@ -55,9 +55,9 @@ export interface AppChildTreeItemData extends BaseChildTreeItemData {
   iconName: string
 }
 
-export interface AppTreeItemData extends BaseTreeItemData {
+export interface UserAppTreeItemData extends BaseTreeItemData {
   appId: string
-  children: AppTreeItem[]
+  children: UserAppTreeItem[]
   description: string
   iconName: string
   memoryUsage: number
@@ -102,7 +102,7 @@ export interface UserTreeItemData extends BaseTreeItemData {
 
 export interface Events {
   activate: [context: ExtensionContext]
-  appUpdate: [oldApp: AppTreeItem, newApp: AppTreeItem]
+  appUpdate: [oldApp: UserAppTreeItem, newApp: UserAppTreeItem]
   authorized: []
   debug: Parameters<LogOutputChannel["debug"]>
   error: [error: Error | unknown]

--- a/src/commands/apps/backup.ts
+++ b/src/commands/apps/backup.ts
@@ -4,8 +4,8 @@ import { existsSync } from "fs";
 import { ProgressLocation, Uri, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 import { ConfigKeys } from "../../utils/constants";
 
 export default class extends Command {
@@ -18,7 +18,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item: AppTreeItem) {
+  async run(task: TaskData, item: UserAppTreeItem) {
     const workspaceAvailable = this.core.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
     if (workspaceAvailable) workspaceFolder = await this.core.getWorkspaceFolder({ token: task.token });

--- a/src/commands/apps/commit.ts
+++ b/src/commands/apps/commit.ts
@@ -4,8 +4,8 @@ import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
 import { socketCommit } from "../../services/discloud/socket/actions/commit";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 import FileSystem from "../../utils/FileSystem";
 import Zip from "../../utils/Zip";
 import { ApiActionsStrategy, ConfigKeys } from "../../utils/constants";
@@ -20,7 +20,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item: AppTreeItem) {
+  async run(task: TaskData, item: UserAppTreeItem) {
     const workspaceFolder = await this.core.getWorkspaceFolder({ token: task.token });
     if (!workspaceFolder) throw Error(t("no.workspace.folder.found"));
 
@@ -53,7 +53,7 @@ export default class extends Command {
     await this[strategy](task, buffer, item);
   }
 
-  async rest(task: TaskData, buffer: Buffer, app: AppTreeItem) {
+  async rest(task: TaskData, buffer: Buffer, app: UserAppTreeItem) {
     task.progress.report({ increment: -1, message: t("committing") });
 
     const file = await resolveFile(buffer, "file.zip");
@@ -67,13 +67,13 @@ export default class extends Command {
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await this.core.appTree.fetch();
+      await this.core.userAppTree.fetch();
 
       if (response.logs) this.logger(app.output ?? app.appId, response.logs);
     }
   }
 
-  async socket(task: TaskData, buffer: Buffer, app: AppTreeItem) {
+  async socket(task: TaskData, buffer: Buffer, app: UserAppTreeItem) {
     await socketCommit(task, buffer, app);
   }
 }

--- a/src/commands/apps/copy.id.ts
+++ b/src/commands/apps/copy.id.ts
@@ -2,8 +2,8 @@ import { t } from "@vscode/l10n";
 import { env, window } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -12,7 +12,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     await env.clipboard.writeText(item.appId);
 
     void window.showInformationMessage(t("copied.appid"));

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -3,8 +3,8 @@ import { type RESTDeleteApiAppDeleteResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,7 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
@@ -27,7 +27,7 @@ export default class extends Command {
       this.showApiMessage(response);
 
       if (response.status === "ok") {
-        this.core.appTree.delete(item.appId);
+        this.core.userAppTree.delete(item.appId);
       }
     }
   }

--- a/src/commands/apps/import.ts
+++ b/src/commands/apps/import.ts
@@ -5,8 +5,8 @@ import { existsSync } from "fs";
 import { ProgressLocation, Uri, commands, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 import { ConfigKeys } from "../../utils/constants";
 
 export default class extends Command {
@@ -19,7 +19,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item: AppTreeItem) {
+  async run(task: TaskData, item: UserAppTreeItem) {
     const workspaceAvailable = this.core.workspaceAvailable;
     let workspaceFolder: Uri | undefined;
     if (workspaceAvailable) workspaceFolder = await this.core.getWorkspaceFolder();

--- a/src/commands/apps/logs.ts
+++ b/src/commands/apps/logs.ts
@@ -3,8 +3,8 @@ import { type RESTGetApiAppLogResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,7 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     const response = await this.core.api.get<RESTGetApiAppLogResult>(Routes.appLogs(item.appId));
     if (!response) return;
 

--- a/src/commands/apps/mods/add.ts
+++ b/src/commands/apps/mods/add.ts
@@ -3,8 +3,8 @@ import { ModPermissionsBF, type RESTPostApiAppTeamResult, Routes } from "disclou
 import { CancellationError, ProgressLocation, type QuickPickItem, window } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";
-import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
+import type UserAppTreeItem from "../../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,7 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     const modID = await window.showInputBox({
       prompt: t("input.mod.add.prompt"),
     });

--- a/src/commands/apps/mods/edit.ts
+++ b/src/commands/apps/mods/edit.ts
@@ -3,8 +3,8 @@ import { ModPermissionsBF, type RESTPutApiAppTeamResult, Routes } from "discloud
 import { CancellationError, ProgressLocation, type QuickPickItem, window } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";
-import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
+import type UserAppTreeItem from "../../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,7 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item: AppTreeItem) {
+  async run(task: TaskData, item: UserAppTreeItem) {
     const mod = await this.pickAppMod(item.appId, task);
     if (!mod) throw Error(t("missing.moderator"));
 

--- a/src/commands/apps/mods/rem.ts
+++ b/src/commands/apps/mods/rem.ts
@@ -3,8 +3,8 @@ import { type RESTDeleteApiAppTeamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";
-import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
+import type UserAppTreeItem from "../../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,7 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item: AppTreeItem) {
+  async run(task: TaskData, item: UserAppTreeItem) {
     const mod = await this.pickAppMod(item.appId, task);
     if (!mod) throw Error(t("missing.moderator"));
 

--- a/src/commands/apps/profile/avatar.ts
+++ b/src/commands/apps/profile/avatar.ts
@@ -3,8 +3,8 @@ import { type BaseApiApp, DiscloudConfig, DiscloudConfigScopes, type RESTApiBase
 import { CancellationError } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";
-import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
+import type UserAppTreeItem from "../../../structures/UserAppTreeItem";
 import InputBox from "../../../utils/Input";
 
 export default class extends Command {
@@ -12,7 +12,7 @@ export default class extends Command {
     super();
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     const avatarURL = await InputBox.getExternalImageURL({
       prompt: t("input.avatar.prompt"),
       required: true,
@@ -28,7 +28,7 @@ export default class extends Command {
       this.showApiMessage(response);
 
       if (response.status === "ok") {
-        this.core.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, avatarURL });
+        this.core.userAppTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, avatarURL });
 
         const workspaceFolder = await this.core.getWorkspaceFolder({ fallbackUserChoice: false });
 

--- a/src/commands/apps/profile/name.ts
+++ b/src/commands/apps/profile/name.ts
@@ -3,15 +3,15 @@ import { type BaseApiApp, DiscloudConfig, DiscloudConfigScopes, type RESTApiBase
 import { CancellationError, window } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";
-import type AppTreeItem from "../../../structures/AppTreeItem";
 import Command from "../../../structures/Command";
+import type UserAppTreeItem from "../../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
     super();
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     const name = await window.showInputBox({
       prompt: t("input.name.prompt"),
       validateInput(value) {
@@ -32,7 +32,7 @@ export default class extends Command {
       this.showApiMessage(response);
 
       if (response.status === "ok") {
-        this.core.appTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, name });
+        this.core.userAppTree.editRawApp(item.appId, <BaseApiApp>{ id: item.appId, name });
 
         const workspaceFolder = await this.core.getWorkspaceFolder({ fallbackUserChoice: false });
 

--- a/src/commands/apps/ram.ts
+++ b/src/commands/apps/ram.ts
@@ -5,8 +5,8 @@ import { AppType } from "../../@enum";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
 import core from "../../extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 import InputBox from "../../utils/Input";
 
 export default class extends Command {
@@ -19,7 +19,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     const min = item.type === AppType.site ? 512 : 100;
     const max = this.core.user.totalRamMb - (core.user.ramUsedMb - item.data.ram);
 
@@ -41,7 +41,7 @@ export default class extends Command {
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await this.core.appTree.fetch();
+      await this.core.userAppTree.fetch();
     }
   }
 }

--- a/src/commands/apps/refresh.ts
+++ b/src/commands/apps/refresh.ts
@@ -7,6 +7,6 @@ export default class extends Command {
   }
 
   async run() {
-    await this.core.appTree.fetch();
+    await this.core.userAppTree.fetch();
   }
 }

--- a/src/commands/apps/restart.ts
+++ b/src/commands/apps/restart.ts
@@ -3,8 +3,8 @@ import { type RESTPutApiAppRestartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,7 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
@@ -26,7 +26,7 @@ export default class extends Command {
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await this.core.appTree.fetch();
+      await this.core.userAppTree.fetch();
     }
   }
 }

--- a/src/commands/apps/start.ts
+++ b/src/commands/apps/start.ts
@@ -3,8 +3,8 @@ import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,14 +16,14 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     const response = await this.core.api.put<RESTPutApiAppStartResult>(Routes.appStart(item.appId));
     if (!response) return;
 
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await this.core.appTree.fetch();
+      await this.core.userAppTree.fetch();
     }
   }
 }

--- a/src/commands/apps/status.ts
+++ b/src/commands/apps/status.ts
@@ -2,8 +2,8 @@ import { t } from "@vscode/l10n";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -15,7 +15,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
-    await this.core.appTree.getStatus(item.appId);
+  async run(_: TaskData, item: UserAppTreeItem) {
+    await this.core.userAppTree.getStatus(item.appId);
   }
 }

--- a/src/commands/apps/stop.ts
+++ b/src/commands/apps/stop.ts
@@ -3,8 +3,8 @@ import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
@@ -16,7 +16,7 @@ export default class extends Command {
     });
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     if (!await this.confirmAction())
       throw new CancellationError();
 
@@ -26,7 +26,7 @@ export default class extends Command {
     if ("status" in response) {
       this.showApiMessage(response);
 
-      await this.core.appTree.fetch();
+      await this.core.userAppTree.fetch();
     }
   }
 }

--- a/src/commands/apps/terminal.ts
+++ b/src/commands/apps/terminal.ts
@@ -1,15 +1,15 @@
 import { type Uri, window } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
-import type AppTreeItem from "../../structures/AppTreeItem";
 import Command from "../../structures/Command";
+import type UserAppTreeItem from "../../structures/UserAppTreeItem";
 
 export default class extends Command {
   constructor(readonly core: ExtensionCore) {
     super();
   }
 
-  async run(_: TaskData, item: AppTreeItem) {
+  async run(_: TaskData, item: UserAppTreeItem) {
     const terminal = window.createTerminal({
       env: { DISCLOUD_TOKEN: await this.core.secrets.getToken() },
       iconPath: item.iconPath as Uri,

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -4,9 +4,9 @@ import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../@types";
 import type ExtensionCore from "../core/extension";
 import { socketCommit } from "../services/discloud/socket/actions/commit";
-import AppTreeItem from "../structures/AppTreeItem";
 import Command from "../structures/Command";
 import type TeamAppTreeItem from "../structures/TeamAppTreeItem";
+import UserAppTreeItem from "../structures/UserAppTreeItem";
 import FileSystem from "../utils/FileSystem";
 import Zip from "../utils/Zip";
 import { pickApp } from "../utils/apps";
@@ -61,14 +61,14 @@ export default class extends Command {
     await this[strategy](task, buffer, item);
   }
 
-  async rest(task: TaskData, buffer: Buffer, app: AppTreeItem | TeamAppTreeItem) {
+  async rest(task: TaskData, buffer: Buffer, app: UserAppTreeItem | TeamAppTreeItem) {
     task.progress.report({ increment: -1, message: t("committing") });
 
     const file = await resolveFile(buffer, "file.zip");
 
     const files: File[] = [file];
 
-    const isUserApp = app instanceof AppTreeItem;
+    const isUserApp = app instanceof UserAppTreeItem;
 
     const response = await this.core.api.put<RESTPutApiAppCommitResult>(
       isUserApp ? Routes.appCommit(app.appId) : Routes.teamCommit(app.appId),
@@ -80,7 +80,7 @@ export default class extends Command {
       this.showApiMessage(response);
 
       if (isUserApp)
-        await this.core.appTree.fetch();
+        await this.core.userAppTree.fetch();
       else
         await this.core.teamAppTree.fetch();
 
@@ -88,7 +88,7 @@ export default class extends Command {
     }
   }
 
-  async socket(task: TaskData, buffer: Buffer, app: AppTreeItem | TeamAppTreeItem) {
+  async socket(task: TaskData, buffer: Buffer, app: UserAppTreeItem | TeamAppTreeItem) {
     await socketCommit(task, buffer, app);
   }
 }

--- a/src/commands/domain/refresh.ts
+++ b/src/commands/domain/refresh.ts
@@ -7,6 +7,6 @@ export default class extends Command {
   }
 
   async run() {
-    await this.core.appTree.fetch();
+    await this.core.userAppTree.fetch();
   }
 }

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -3,9 +3,9 @@ import { DiscloudConfig, DiscloudConfigScopes, type RESTGetApiAppLogResult, Rout
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../@types";
 import type ExtensionCore from "../core/extension";
-import AppTreeItem from "../structures/AppTreeItem";
 import Command from "../structures/Command";
 import type TeamAppTreeItem from "../structures/TeamAppTreeItem";
+import UserAppTreeItem from "../structures/UserAppTreeItem";
 import { pickApp } from "../utils/apps";
 
 export default class extends Command {
@@ -18,7 +18,7 @@ export default class extends Command {
     });
   }
 
-  async run(task: TaskData, item?: AppTreeItem | TeamAppTreeItem) {
+  async run(task: TaskData, item?: UserAppTreeItem | TeamAppTreeItem) {
     if (!item) {
       const workspaceFolder = await this.core.getWorkspaceFolder({ fallbackUserChoice: false });
       if (workspaceFolder) {
@@ -26,7 +26,7 @@ export default class extends Command {
 
         const ID = dConfig.get(DiscloudConfigScopes.ID);
 
-        if (ID) item = this.core.appTree.children.get(ID) ?? this.core.teamAppTree.children.get(ID)!;
+        if (ID) item = this.core.userAppTree.children.get(ID) ?? this.core.teamAppTree.children.get(ID)!;
 
         if (!item) throw Error(t("missing.appid"));
       } else {
@@ -39,7 +39,7 @@ export default class extends Command {
     }
 
     const response = await this.core.api.get<RESTGetApiAppLogResult>(
-      item instanceof AppTreeItem
+      item instanceof UserAppTreeItem
         ? Routes.appLogs(item.appId)
         : Routes.teamLogs(item.appId),
     );

--- a/src/commands/subdomain/refresh.ts
+++ b/src/commands/subdomain/refresh.ts
@@ -7,6 +7,6 @@ export default class extends Command {
   }
 
   async run() {
-    await this.core.appTree.fetch();
+    await this.core.userAppTree.fetch();
   }
 }

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -81,7 +81,7 @@ export default class extends Command {
 
       if ("app" in response && response.app) {
         dConfig.update({ ID: response.app.id, AVATAR: response.app.avatarURL });
-        await this.core.appTree.fetch();
+        await this.core.userAppTree.fetch();
       }
 
       if (response.logs) {

--- a/src/core/extension.ts
+++ b/src/core/extension.ts
@@ -6,10 +6,10 @@ import { type Events, type GetWorkspaceFolderOptions, type TaskData } from "../@
 import { commandsRegister } from "../commands";
 import { loadEvents } from "../events";
 import SecretStorage from "../modules/storage/SecretStorage";
-import AppTreeDataProvider from "../providers/AppTreeDataProvider";
 import CustomDomainTreeDataProvider from "../providers/CustomDomainTreeDataProvider";
 import SubDomainTreeDataProvider from "../providers/SubDomainTreeDataProvider";
 import TeamAppTreeDataProvider from "../providers/TeamAppTreeDataProvider";
+import UserAppTreeDataProvider from "../providers/UserAppTreeDataProvider";
 import UserTreeDataProvider from "../providers/UserTreeDataProvider";
 import REST from "../services/discloud/REST";
 import { UserAgent } from "../services/discloud/UserAgent";
@@ -30,10 +30,10 @@ export default class ExtensionCore extends EventEmitter<Events> implements Dispo
 
   declare readonly statusBar: DiscloudStatusBarItem;
 
-  declare readonly appTree: AppTreeDataProvider;
   declare readonly customDomainTree: CustomDomainTreeDataProvider;
   declare readonly subDomainTree: SubDomainTreeDataProvider;
   declare readonly teamAppTree: TeamAppTreeDataProvider;
+  declare readonly userAppTree: UserAppTreeDataProvider;
   declare readonly userTree: UserTreeDataProvider;
 
   readonly commands = new Map<string, Command>();
@@ -171,10 +171,10 @@ export default class ExtensionCore extends EventEmitter<Events> implements Dispo
 
   #loadTreeViews(context: ExtensionContext = this.context) {
     Object.defineProperties(this, {
-      appTree: { value: new AppTreeDataProvider(this) },
       customDomainTree: { value: new CustomDomainTreeDataProvider(context) },
       subDomainTree: { value: new SubDomainTreeDataProvider(context) },
       teamAppTree: { value: new TeamAppTreeDataProvider(this) },
+      userAppTree: { value: new UserAppTreeDataProvider(this) },
       userTree: { value: new UserTreeDataProvider(context) },
     });
   }

--- a/src/events/activate.ts
+++ b/src/events/activate.ts
@@ -20,7 +20,7 @@ core.on("activate", async function (context) {
 
   const disposableChangeConfiguration = workspace.onDidChangeConfiguration(event => {
     if (event.affectsConfiguration("discloud.app.sort")) {
-      core.appTree.refresh();
+      core.userAppTree.refresh();
 
       return;
     }
@@ -32,17 +32,17 @@ core.on("activate", async function (context) {
     }
 
     if (event.affectsConfiguration("discloud.app.separate.by.type")) {
-      core.appTree.refresh();
+      core.userAppTree.refresh();
 
       return;
     }
 
     if (event.affectsConfiguration("discloud.app.show.avatar.instead.status")) {
-      for (const app of core.appTree.children.values()) {
+      for (const app of core.userAppTree.children.values()) {
         app._patch({});
       }
 
-      core.appTree.refresh();
+      core.userAppTree.refresh();
 
       return;
     }

--- a/src/events/vscode.ts
+++ b/src/events/vscode.ts
@@ -6,7 +6,7 @@ core.on("vscode", async function (user) {
   core.userTree.set(user);
 
   if ("appsStatus" in user)
-    core.appTree.setRawApps(user.appsStatus);
+    core.userAppTree.setRawApps(user.appsStatus);
 
   if ("appsTeam" in user)
     core.teamAppTree.setRawApps(user.appsTeam.map(id => ({ id })));

--- a/src/providers/UserAppTreeDataProvider.ts
+++ b/src/providers/UserAppTreeDataProvider.ts
@@ -4,17 +4,17 @@ import { type ProviderResult, type TreeItem, commands, window } from "vscode";
 import { type AppType } from "../@enum";
 import { type ApiVscodeApp } from "../@types";
 import type ExtensionCore from "../core/extension";
-import AppTreeItem from "../structures/AppTreeItem";
-import AppTypeTreeItemView from "../structures/AppTypeTreeItemView";
 import DisposableMap from "../structures/DisposableMap";
 import EmptyAppListTreeItem from "../structures/EmptyAppListTreeItem";
+import UserAppTreeItem from "../structures/UserAppTreeItem";
+import AppTypeTreeItemView from "../structures/UserAppTypeTreeItemView";
 import { ConfigKeys, EMPTY_TREE_ITEM_ID, SortBy, TreeViewIds } from "../utils/constants";
 import { compareBooleans, compareNumbers } from "../utils/utils";
 import BaseTreeDataProvider from "./BaseTreeDataProvider";
 
-type Item = AppTreeItem
+type Item = UserAppTreeItem
 
-export default class AppTreeDataProvider extends BaseTreeDataProvider<Item> {
+export default class UserAppTreeDataProvider extends BaseTreeDataProvider<Item> {
   constructor(readonly core: ExtensionCore) {
     super(core.context, TreeViewIds.discloudUserApps);
 
@@ -89,9 +89,9 @@ export default class AppTreeDataProvider extends BaseTreeDataProvider<Item> {
     if (sortOnlineFirst) children.sort((a, b) => compareBooleans(a.online, b.online));
   }
 
-  getChildren(element?: AppTreeItem): ProviderResult<AppTreeItem[]>;
+  getChildren(element?: UserAppTreeItem): ProviderResult<UserAppTreeItem[]>;
   getChildren(element?: AppTypeTreeItemView): ProviderResult<AppTypeTreeItemView[]>;
-  getChildren(element?: AppTreeItem | AppTypeTreeItemView): ProviderResult<TreeItem[]> {
+  getChildren(element?: UserAppTreeItem | AppTypeTreeItemView): ProviderResult<TreeItem[]> {
     if (element) {
       if (element instanceof AppTypeTreeItemView) {
         const children = element.children.values().toArray();
@@ -195,7 +195,7 @@ export default class AppTreeDataProvider extends BaseTreeDataProvider<Item> {
     } else {
       this.children.dispose(EMPTY_TREE_ITEM_ID);
 
-      const child = new AppTreeItem(data);
+      const child = new UserAppTreeItem(data);
 
       this._getView(child.type).set(child.appId, child);
 

--- a/src/services/discloud/socket/actions/commit.ts
+++ b/src/services/discloud/socket/actions/commit.ts
@@ -5,14 +5,14 @@ import { stripVTControlCharacters } from "util";
 import { window } from "vscode";
 import { type TaskData } from "../../../../@types";
 import core from "../../../../extension";
-import AppTreeItem from "../../../../structures/AppTreeItem";
 import type TeamAppTreeItem from "../../../../structures/TeamAppTreeItem";
+import UserAppTreeItem from "../../../../structures/UserAppTreeItem";
 import { MAX_FILE_SIZE } from "../../constants";
 import SocketClient from "../client";
 import { SocketEvents } from "../enum/events";
 import { type SocketEventUploadData } from "../types";
 
-export async function socketCommit(task: TaskData, buffer: Buffer, app: AppTreeItem | TeamAppTreeItem) {
+export async function socketCommit(task: TaskData, buffer: Buffer, app: UserAppTreeItem | TeamAppTreeItem) {
   await new Promise<void>((resolve, reject) => {
     const debugCode = app.appId;
 
@@ -26,8 +26,8 @@ export async function socketCommit(task: TaskData, buffer: Buffer, app: AppTreeI
 
     if (buffer.length > MAX_FILE_SIZE) return reject(t("file.too.big", { value }));
 
-    const isUserApp = app instanceof AppTreeItem;
-    const appTree = isUserApp ? core.appTree : core.teamAppTree;
+    const isUserApp = app instanceof UserAppTreeItem;
+    const appTree = isUserApp ? core.userAppTree : core.teamAppTree;
 
     const url = new URL(`${core.api.baseURL}/ws${isUserApp ? Routes.appCommit(app.appId) : Routes.teamCommit(app.appId)}`);
 

--- a/src/services/discloud/socket/actions/upload.ts
+++ b/src/services/discloud/socket/actions/upload.ts
@@ -101,7 +101,7 @@ export async function socketUpload(task: TaskData, buffer: Buffer, dConfig: Disc
             ...data.app,
           };
 
-          core.appTree.addRawApp(app); // TODO: fix ApiUploadApp
+          core.userAppTree.addRawApp(app); // TODO: fix ApiUploadApp
         }
 
         if (data.logs) showLog(data.logs);

--- a/src/structures/DiscloudStatusBarItem.ts
+++ b/src/structures/DiscloudStatusBarItem.ts
@@ -144,7 +144,7 @@ export default class DiscloudStatusBarItem extends BaseStatusBarItem {
 
       if (!ID) continue;
 
-      app = this.core.appTree.children.get(ID) ?? this.core.teamAppTree.children.get(ID);
+      app = this.core.userAppTree.children.get(ID) ?? this.core.teamAppTree.children.get(ID);
 
       if (app && (app.label || app.data.name || app.data.description)) break;
     }
@@ -165,7 +165,7 @@ export default class DiscloudStatusBarItem extends BaseStatusBarItem {
 
     if (!ID) return false;
 
-    const app = this.core.appTree.children.get(ID) ?? this.core.teamAppTree.children.get(ID);
+    const app = this.core.userAppTree.children.get(ID) ?? this.core.teamAppTree.children.get(ID);
 
     if (!app) return false;
 

--- a/src/structures/SubDomainTreeItem.ts
+++ b/src/structures/SubDomainTreeItem.ts
@@ -25,7 +25,7 @@ export default class SubDomainTreeItem extends BaseTreeItem<any> {
     this.subdomain = data.subdomain ?? this.subdomain;
     this.label = data.subdomain ?? this.label;
 
-    const app = core.appTree.children.get(this.subdomain);
+    const app = core.userAppTree.children.get(this.subdomain);
 
     this.iconName = app?.iconName ?? getIconName(data) ?? this.iconName ?? "off";
     this.iconPath = getIconPath(this.iconName);

--- a/src/structures/UserAppChildTreeItem.ts
+++ b/src/structures/UserAppChildTreeItem.ts
@@ -1,15 +1,15 @@
 import { type AppType } from "../@enum";
-import { type AppChildTreeItemData } from "../@types";
+import { type UserAppChildTreeItemData } from "../@types";
 import { getIconPath } from "../utils/utils";
 import BaseChildTreeItem from "./BaseChildTreeItem";
 
-export default class AppChildTreeItem extends BaseChildTreeItem {
+export default class UserAppChildTreeItem extends BaseChildTreeItem {
   readonly iconName: string;
   readonly appId: string;
   declare online: boolean;
   declare readonly type: AppType;
 
-  constructor(data: AppChildTreeItemData) {
+  constructor(data: UserAppChildTreeItemData) {
     super(data.label, data.collapsibleState);
 
     this.appId = data.appId;
@@ -27,7 +27,7 @@ export default class AppChildTreeItem extends BaseChildTreeItem {
     };
   }
 
-  _patch(data: Partial<AppChildTreeItemData>) {
+  _patch(data: Partial<UserAppChildTreeItemData>) {
     if (!data) return this;
 
     super._patch(data);

--- a/src/structures/UserAppTreeItem.ts
+++ b/src/structures/UserAppTreeItem.ts
@@ -2,15 +2,15 @@ import { t } from "@vscode/l10n";
 import { calculatePercentage, type ApiStatusApp } from "discloud.app";
 import { TreeItemCollapsibleState, Uri } from "vscode";
 import { AppType } from "../@enum";
-import { type ApiVscodeApp, type AppChildTreeItemData, type AppTreeItemData } from "../@types";
+import { type ApiVscodeApp, type UserAppChildTreeItemData, type UserAppTreeItemData } from "../@types";
 import core from "../extension";
 import { ConfigKeys } from "../utils/constants";
 import { getIconName, getIconPath } from "../utils/utils";
-import AppChildTreeItem from "./AppChildTreeItem";
+import UserAppChildTreeItem from "./UserAppChildTreeItem";
 import BaseTreeItem from "./BaseTreeItem";
 
-export default class AppTreeItem extends BaseTreeItem<AppChildTreeItem> {
-  constructor(public readonly data: Partial<AppTreeItemData & ApiStatusApp> & ApiVscodeApp) {
+export default class UserAppTreeItem extends BaseTreeItem<UserAppChildTreeItem> {
+  constructor(public readonly data: Partial<UserAppTreeItemData & ApiStatusApp> & ApiVscodeApp) {
     data.label ??= data.appId ?? data.id;
 
     super(data.label, data.collapsibleState);
@@ -49,7 +49,7 @@ export default class AppTreeItem extends BaseTreeItem<AppChildTreeItem> {
     return this.data.online;
   }
 
-  _patch(data: Partial<AppTreeItemData & ApiVscodeApp & ApiStatusApp>): this {
+  _patch(data: Partial<UserAppTreeItemData & ApiVscodeApp & ApiStatusApp>): this {
     if (!data) return this;
 
     super._patch(data);
@@ -143,7 +143,7 @@ export default class AppTreeItem extends BaseTreeItem<AppChildTreeItem> {
     return this;
   }
 
-  private _addChild(id: string, data: Partial<AppChildTreeItemData>) {
+  private _addChild(id: string, data: Partial<UserAppChildTreeItemData>) {
     data.appId = this.appId;
     data.online = this.online;
     data.appType = this.type;
@@ -155,6 +155,6 @@ export default class AppTreeItem extends BaseTreeItem<AppChildTreeItem> {
       return;
     }
 
-    this.children.set(id, new AppChildTreeItem(<AppChildTreeItemData>data));
+    this.children.set(id, new UserAppChildTreeItem(<UserAppChildTreeItemData>data));
   }
 }

--- a/src/structures/UserAppTypeTreeItemView.ts
+++ b/src/structures/UserAppTypeTreeItemView.ts
@@ -1,10 +1,10 @@
 import { t } from "@vscode/l10n";
 import { TreeItemCollapsibleState } from "vscode";
 import { AppType } from "../@enum";
-import type AppTreeItem from "./AppTreeItem";
 import BaseTreeItem from "./BaseTreeItem";
+import type UserAppTreeItem from "./UserAppTreeItem";
 
-export default class AppTypeTreeItemView extends BaseTreeItem<AppTreeItem> {
+export default class AppTypeTreeItemView extends BaseTreeItem<UserAppTreeItem> {
   constructor(readonly type: AppType) {
     super(t(AppType[type]), TreeItemCollapsibleState.Expanded);
     this.contextValue = this.contextKey;
@@ -27,7 +27,7 @@ export default class AppTypeTreeItemView extends BaseTreeItem<AppTreeItem> {
     this.label = `${t(AppType[this.type])} (${this.children.size})`;
   }
 
-  set(key: string, app: AppTreeItem) {
+  set(key: string, app: UserAppTreeItem) {
     this.children.set(key, app);
     this.refresh();
   }


### PR DESCRIPTION
- Updated command implementations to use UserAppTreeItem instead of AppTreeItem for better clarity and separation of user-specific applications.
- Refactored methods in various commands (edit, remove, profile, etc.) to interact with userAppTree instead of appTree.
- Introduced UserAppTreeDataProvider to manage user applications in the tree view.
- Adjusted socket actions for commit and upload to handle UserAppTreeItem.
- Updated utility functions to accommodate changes in app selection and fetching logic.
- Ensured that all references to appTree are replaced with userAppTree where applicable.