### PR TITLE
refactor: migrate from `discloud.app` to `@discloudapp/api-types` and `@discloudapp/util`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1289,10 +1289,11 @@
     "test": "vscode-test"
   },
   "dependencies": {
+    "@discloudapp/api-types": "^1.0.2",
+    "@discloudapp/util": "^1.2.3",
     "@vscode/l10n": "^0.0.18",
     "adm-zip": "^0.5.16",
     "bytes": "^3.1.2",
-    "discloud.app": "^1.1.1",
     "jose": "^6.0.12",
     "json-schema-library": "^10.1.2",
     "ws": "^8.18.3"

--- a/src/@types/api.ts
+++ b/src/@types/api.ts
@@ -1,4 +1,4 @@
-import type { BaseApiApp, RESTApiBaseResult } from "discloud.app";
+import { type BaseApiApp, type RESTApiBaseResult } from "@discloudapp/api-types/v2";
 import { type AppType } from "../@enum";
 
 export interface RESTGetApiVscode extends RESTApiBaseResult {

--- a/src/authentication/pat/provider.ts
+++ b/src/authentication/pat/provider.ts
@@ -1,5 +1,5 @@
+import { type RESTGetApiUserResult, RouteBases, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTGetApiUserResult, RouteBases, Routes } from "discloud.app";
 import { setTimeout as sleep } from "timers/promises";
 import { authentication, type AuthenticationProviderAuthenticationSessionsChangeEvent, type AuthenticationProviderSessionOptions, type AuthenticationSession, type AuthenticationSessionAccountInformation, type Event, EventEmitter, type ExtensionContext, type SecretStorage, window } from "vscode";
 import { tokenIsDiscloudJwt } from "../../services/discloud/utils";

--- a/src/commands/apps/backup.ts
+++ b/src/commands/apps/backup.ts
@@ -1,5 +1,5 @@
+import { type RESTGetApiAppBackupResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTGetApiAppBackupResult, Routes } from "discloud.app";
 import { existsSync } from "fs";
 import { ProgressLocation, Uri, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";

--- a/src/commands/apps/commit.ts
+++ b/src/commands/apps/commit.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppCommitResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppCommitResult, Routes, resolveFile } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
@@ -56,7 +56,7 @@ export default class extends Command {
   async rest(task: TaskData, buffer: Buffer, app: UserAppTreeItem) {
     task.progress.report({ increment: -1, message: t("committing") });
 
-    const file = await resolveFile(buffer, "file.zip");
+    const file = new File([buffer], "file.zip");
 
     const files: File[] = [file];
 

--- a/src/commands/apps/delete.ts
+++ b/src/commands/apps/delete.ts
@@ -1,5 +1,5 @@
+import { type RESTDeleteApiAppDeleteResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTDeleteApiAppDeleteResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/apps/import.ts
+++ b/src/commands/apps/import.ts
@@ -1,6 +1,6 @@
+import { type RESTGetApiAppBackupResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
 import AdmZip from "adm-zip";
-import { type RESTGetApiAppBackupResult, Routes } from "discloud.app";
 import { existsSync } from "fs";
 import { ProgressLocation, Uri, commands, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";

--- a/src/commands/apps/logs.ts
+++ b/src/commands/apps/logs.ts
@@ -1,5 +1,5 @@
+import { type RESTGetApiAppLogResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTGetApiAppLogResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/apps/mods/add.ts
+++ b/src/commands/apps/mods/add.ts
@@ -1,5 +1,6 @@
+import { type RESTPostApiAppTeamResult, Routes } from "@discloudapp/api-types/v2";
+import { ModPermissionsBF } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { ModPermissionsBF, type RESTPostApiAppTeamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation, type QuickPickItem, window } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";

--- a/src/commands/apps/mods/edit.ts
+++ b/src/commands/apps/mods/edit.ts
@@ -1,5 +1,6 @@
+import { type RESTPutApiAppTeamResult, Routes } from "@discloudapp/api-types/v2";
+import { ModPermissionsBF } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { ModPermissionsBF, type RESTPutApiAppTeamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation, type QuickPickItem, window } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";

--- a/src/commands/apps/mods/rem.ts
+++ b/src/commands/apps/mods/rem.ts
@@ -1,5 +1,5 @@
+import { type RESTDeleteApiAppTeamResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTDeleteApiAppTeamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";

--- a/src/commands/apps/profile/avatar.ts
+++ b/src/commands/apps/profile/avatar.ts
@@ -1,5 +1,6 @@
+import { type BaseApiApp, DiscloudConfigScopes, type RESTApiBaseResult, Routes } from "@discloudapp/api-types/v2";
+import { DiscloudConfig } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { type BaseApiApp, DiscloudConfig, DiscloudConfigScopes, type RESTApiBaseResult, Routes } from "discloud.app";
 import { CancellationError } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";

--- a/src/commands/apps/profile/name.ts
+++ b/src/commands/apps/profile/name.ts
@@ -1,5 +1,6 @@
+import { type BaseApiApp, DiscloudConfigScopes, type RESTApiBaseResult, Routes } from "@discloudapp/api-types/v2";
+import { DiscloudConfig } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { type BaseApiApp, DiscloudConfig, DiscloudConfigScopes, type RESTApiBaseResult, Routes } from "discloud.app";
 import { CancellationError, window } from "vscode";
 import { type TaskData } from "../../../@types";
 import type ExtensionCore from "../../../core/extension";

--- a/src/commands/apps/ram.ts
+++ b/src/commands/apps/ram.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppRamResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppRamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { AppType } from "../../@enum";
 import { type TaskData } from "../../@types";

--- a/src/commands/apps/restart.ts
+++ b/src/commands/apps/restart.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppRestartResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppRestartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/apps/start.ts
+++ b/src/commands/apps/start.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppStartResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/apps/stop.ts
+++ b/src/commands/apps/stop.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppStartResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppCommitResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppCommitResult, Routes, resolveFile } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../@types";
 import type ExtensionCore from "../core/extension";
@@ -64,7 +64,7 @@ export default class extends Command {
   async rest(task: TaskData, buffer: Buffer, app: UserAppTreeItem | TeamAppTreeItem) {
     task.progress.report({ increment: -1, message: t("committing") });
 
-    const file = await resolveFile(buffer, "file.zip");
+    const file = new File([buffer], "file.zip");
 
     const files: File[] = [file];
 

--- a/src/commands/create.config.ts
+++ b/src/commands/create.config.ts
@@ -1,5 +1,5 @@
+import { DiscloudConfig } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { DiscloudConfig } from "discloud.app";
 import { Uri, workspace } from "vscode";
 import type ExtensionCore from "../core/extension";
 import WarningError from "../errors/warning";

--- a/src/commands/logs.ts
+++ b/src/commands/logs.ts
@@ -1,5 +1,6 @@
+import { DiscloudConfigScopes, type RESTGetApiAppLogResult, Routes } from "@discloudapp/api-types/v2";
+import { DiscloudConfig } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { DiscloudConfig, DiscloudConfigScopes, type RESTGetApiAppLogResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../@types";
 import type ExtensionCore from "../core/extension";

--- a/src/commands/team/backup.ts
+++ b/src/commands/team/backup.ts
@@ -1,5 +1,5 @@
+import { type RESTGetApiAppBackupResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTGetApiAppBackupResult, Routes } from "discloud.app";
 import { existsSync } from "fs";
 import { ProgressLocation, Uri, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";

--- a/src/commands/team/commit.ts
+++ b/src/commands/team/commit.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppCommitResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppCommitResult, Routes, resolveFile } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";
@@ -56,7 +56,7 @@ export default class extends Command {
   async rest(task: TaskData, buffer: Buffer, app: TeamAppTreeItem) {
     task.progress.report({ increment: -1, message: t("committing") });
 
-    const file = await resolveFile(buffer, "file.zip");
+    const file = new File([buffer], "file.zip");
 
     const files: File[] = [file];
 

--- a/src/commands/team/import.ts
+++ b/src/commands/team/import.ts
@@ -1,6 +1,6 @@
+import { type RESTGetApiAppBackupResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
 import AdmZip from "adm-zip";
-import { type RESTGetApiAppBackupResult, Routes } from "discloud.app";
 import { existsSync } from "fs";
 import { ProgressLocation, Uri, commands, window, workspace } from "vscode";
 import { type TaskData } from "../../@types";

--- a/src/commands/team/logs.ts
+++ b/src/commands/team/logs.ts
@@ -1,5 +1,5 @@
+import { type RESTGetApiAppLogResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTGetApiAppLogResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/team/ram.ts
+++ b/src/commands/team/ram.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppRamResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppRamResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { AppType } from "../../@enum";
 import { type TaskData } from "../../@types";

--- a/src/commands/team/restart.ts
+++ b/src/commands/team/restart.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppRestartResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppRestartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/team/start.ts
+++ b/src/commands/team/start.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppStartResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/team/stop.ts
+++ b/src/commands/team/stop.ts
@@ -1,5 +1,5 @@
+import { type RESTPutApiAppStartResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTPutApiAppStartResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation } from "vscode";
 import { type TaskData } from "../../@types";
 import type ExtensionCore from "../../core/extension";

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -1,5 +1,6 @@
+import { type RESTPostApiUploadResult, Routes } from "@discloudapp/api-types/v2";
+import { DiscloudConfig } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { DiscloudConfig, resolveFile, type RESTPostApiUploadResult, Routes } from "discloud.app";
 import { CancellationError, ProgressLocation, Uri } from "vscode";
 import { type TaskData } from "../@types";
 import type ExtensionCore from "../core/extension";
@@ -68,7 +69,7 @@ export default class extends Command {
   async rest(task: TaskData, buffer: Buffer, dConfig: DiscloudConfig) {
     task.progress.report({ increment: -1, message: t("uploading") });
 
-    const file = await resolveFile(buffer, "file.zip");
+    const file = new File([buffer], "file.zip");
 
     const files: File[] = [file];
 

--- a/src/providers/BaseLanguageProvider.ts
+++ b/src/providers/BaseLanguageProvider.ts
@@ -1,4 +1,4 @@
-import { DiscloudConfigScopes } from "discloud.app";
+import { DiscloudConfigScopes } from "@discloudapp/api-types/v2";
 import { readFile } from "fs/promises";
 import type { JSONSchema7 } from "json-schema";
 import { compileSchema, type SchemaNode } from "json-schema-library";

--- a/src/providers/TeamAppTreeDataProvider.ts
+++ b/src/providers/TeamAppTreeDataProvider.ts
@@ -1,5 +1,5 @@
+import { type ApiStatusApp, type ApiTeamApps, type BaseApiApp, type RESTGetApiAppStatusResult, type RESTGetApiTeamResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type ApiStatusApp, type ApiTeamApps, type BaseApiApp, type RESTGetApiAppStatusResult, type RESTGetApiTeamResult, Routes } from "discloud.app";
 import { type ProviderResult, type TreeItem, commands, window } from "vscode";
 import type ExtensionCore from "../core/extension";
 import EmptyAppListTreeItem from "../structures/EmptyAppListTreeItem";

--- a/src/providers/UserAppTreeDataProvider.ts
+++ b/src/providers/UserAppTreeDataProvider.ts
@@ -1,5 +1,5 @@
+import { type ApiStatusApp, type BaseApiApp, type RESTGetApiAppStatusResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type ApiStatusApp, type BaseApiApp, type RESTGetApiAppStatusResult, Routes } from "discloud.app";
 import { type ProviderResult, type TreeItem, commands, window } from "vscode";
 import { type AppType } from "../@enum";
 import { type ApiVscodeApp } from "../@types";

--- a/src/services/discloud/REST.ts
+++ b/src/services/discloud/REST.ts
@@ -1,12 +1,12 @@
+import { RouteBases } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { RouteBases, type RouteLike } from "discloud.app";
 import { EventEmitter } from "events";
 import { window } from "vscode";
 import type ExtensionCore from "../../core/extension";
 import AsyncQueue from "../../modules/async-queue";
 import { RequestMethod } from "./enum";
 import DiscloudAPIError from "./errors/api";
-import { type InternalRequestData, type RequestData, type RequestOptions, type RESTOptions } from "./types";
+import { type InternalRequestData, type RequestData, type RequestOptions, type RESTOptions, type RouteLike } from "./types";
 
 export default class REST extends EventEmitter {
   limit = 60;

--- a/src/services/discloud/socket/actions/commit.ts
+++ b/src/services/discloud/socket/actions/commit.ts
@@ -1,6 +1,6 @@
+import { Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
 import bytes from "bytes";
-import { Routes } from "discloud.app";
 import { stripVTControlCharacters } from "util";
 import { window } from "vscode";
 import { type TaskData } from "../../../../@types";

--- a/src/services/discloud/socket/actions/upload.ts
+++ b/src/services/discloud/socket/actions/upload.ts
@@ -1,6 +1,7 @@
+import { Routes } from "@discloudapp/api-types/v2";
+import { type DiscloudConfig } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
 import bytes from "bytes";
-import { Routes, type DiscloudConfig } from "discloud.app";
 import { stripVTControlCharacters } from "util";
 import { window } from "vscode";
 import { type ApiVscodeApp, type TaskData } from "../../../../@types";

--- a/src/services/discloud/socket/types.ts
+++ b/src/services/discloud/socket/types.ts
@@ -1,4 +1,4 @@
-import type { ApiUploadApp } from "discloud.app";
+import { type ApiUploadApp } from "@discloudapp/api-types/v2";
 import type { RawData } from "ws";
 
 export interface SocketEventsMap<Data extends Record<any, any> = Record<any, any>> {

--- a/src/services/discloud/types.ts
+++ b/src/services/discloud/types.ts
@@ -1,7 +1,8 @@
-import { type RouteLike } from "discloud.app";
 import { type LogOutputChannel } from "vscode";
 import { type RateLimitData } from "../../@types";
 import { type RequestMethod } from "./enum";
+
+export type RouteLike = `/${string}`
 
 export interface RESTEvents {
   debug: [...args: Parameters<LogOutputChannel["debug"]>]

--- a/src/structures/Command.ts
+++ b/src/structures/Command.ts
@@ -1,5 +1,5 @@
+import { type RESTGetApiAppTeamResult, Routes } from "@discloudapp/api-types/v2";
 import { t } from "@vscode/l10n";
-import { type RESTGetApiAppTeamResult, Routes } from "discloud.app";
 import { stripVTControlCharacters } from "util";
 import { type LogOutputChannel, type QuickPickItem, window } from "vscode";
 import { type CommandData, type TaskData } from "../@types";

--- a/src/structures/DiscloudStatusBarItem.ts
+++ b/src/structures/DiscloudStatusBarItem.ts
@@ -1,5 +1,6 @@
+import { DiscloudConfigScopes } from "@discloudapp/api-types/v2";
+import { DiscloudConfig } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { DiscloudConfig, DiscloudConfigScopes } from "discloud.app";
 import { setTimeout as sleep } from "timers/promises";
 import { StatusBarAlignment, ThemeColor, type Uri, window, workspace, type WorkspaceFolder } from "vscode";
 import { type StatusBarItemData, type StatusBarItemOptions } from "../@types";

--- a/src/structures/TeamAppTreeItem.ts
+++ b/src/structures/TeamAppTreeItem.ts
@@ -1,5 +1,6 @@
+import { type ApiStatusApp, type ApiTeamApps, type BaseApiApp } from "@discloudapp/api-types/v2";
+import { calculatePercentage, ModPermissionsBF, type ModPermissionsResolvable } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { type ApiStatusApp, type ApiTeamApps, type BaseApiApp, calculatePercentage, ModPermissionsBF, type ModPermissionsResolvable } from "discloud.app";
 import { type LogOutputChannel, TreeItemCollapsibleState } from "vscode";
 import { AppType } from "../@enum";
 import { type TeamAppChildTreeItemData, type TeamAppTreeItemData } from "../@types";

--- a/src/structures/UserAppTreeItem.ts
+++ b/src/structures/UserAppTreeItem.ts
@@ -1,13 +1,14 @@
+import { type ApiStatusApp } from "@discloudapp/api-types/v2";
+import { calculatePercentage } from "@discloudapp/util";
 import { t } from "@vscode/l10n";
-import { calculatePercentage, type ApiStatusApp } from "discloud.app";
 import { TreeItemCollapsibleState, Uri } from "vscode";
 import { AppType } from "../@enum";
 import { type ApiVscodeApp, type UserAppChildTreeItemData, type UserAppTreeItemData } from "../@types";
 import core from "../extension";
 import { ConfigKeys } from "../utils/constants";
 import { getIconName, getIconPath } from "../utils/utils";
-import UserAppChildTreeItem from "./UserAppChildTreeItem";
 import BaseTreeItem from "./BaseTreeItem";
+import UserAppChildTreeItem from "./UserAppChildTreeItem";
 
 export default class UserAppTreeItem extends BaseTreeItem<UserAppChildTreeItem> {
   constructor(public readonly data: Partial<UserAppTreeItemData & ApiStatusApp> & ApiVscodeApp) {

--- a/src/structures/VSUser.ts
+++ b/src/structures/VSUser.ts
@@ -1,4 +1,4 @@
-import { type RESTPutApiLocaleResult, Routes } from "discloud.app";
+import { type RESTPutApiLocaleResult, Routes } from "@discloudapp/api-types/v2";
 import { type ApiVscodeApp, type ApiVscodeUser, type RESTGetApiVscode } from "../@types";
 import core from "../extension";
 

--- a/src/utils/apps.ts
+++ b/src/utils/apps.ts
@@ -1,10 +1,11 @@
 import { t } from "@vscode/l10n";
-import { DiscloudConfig, DiscloudConfigScopes, ModPermissionsFlags } from "discloud.app";
 import { window, type CancellationToken, type QuickPickItem, type Uri } from "vscode";
 import type { VscodeProgressReporter } from "../@types";
 import core from "../extension";
 import type TeamAppTreeItem from "../structures/TeamAppTreeItem";
 import type UserAppTreeItem from "../structures/UserAppTreeItem";
+import { DiscloudConfig, ModPermissionsFlags } from "@discloudapp/util";
+import { DiscloudConfigScopes } from "@discloudapp/api-types/v2";
 
 interface AppPickerOptions {
   allowOtherAppTypes?: boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,17 +14,7 @@
   dependencies:
     tslib "^2.8.1"
 
-"@discloudapp/rest@^1.0.7":
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/@discloudapp/rest/-/rest-1.0.7.tgz#1a383975f48a658c760db225648809cf6122038f"
-  integrity sha512-yO+h9AlYbUtkV4Lc1tyKxYm1TNxoqqVVLFSsYU+xxICq4eBejml0E8eNM+xsgzq+qzkx/aT/LC1aD4cH4K1zpg==
-  dependencies:
-    "@discloudapp/api-types" "^1.0.2"
-    "@discloudapp/util" "^1.2.2"
-    source-map-support "^0.5.21"
-    tslib "^2.8.1"
-
-"@discloudapp/util@^1.2.2", "@discloudapp/util@^1.2.3":
+"@discloudapp/util@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@discloudapp/util/-/util-1.2.3.tgz#e35b1b2c96e39971f5d4aac782d51e6753e47334"
   integrity sha512-UF0Qk0xZLa5yhvspt7Cl/Z4khaQ1qaFMhaPvHz01TTj3WoZhndP+OAolst8CSCFhYWEVxZGTfBg1LyI0md9Wmg==
@@ -976,18 +966,6 @@ diff@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
   integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
-
-discloud.app@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/discloud.app/-/discloud.app-1.1.1.tgz#067117e5b5b291fdbba2c6db310352bc97de4b96"
-  integrity sha512-AbjAh1cpiThNwirDrrYF7C4QjL3tBI0cL3uQD0r/bAsto3oHFe162SrmqFI9xzB5Z8P/8kLH61ykpYAWQcXfaA==
-  dependencies:
-    "@discloudapp/api-types" "^1.0.2"
-    "@discloudapp/rest" "^1.0.7"
-    "@discloudapp/util" "^1.2.3"
-    source-map-support "^0.5.21"
-    tslib "^2.8.1"
-    zod "^3.25.76"
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -3345,7 +3323,7 @@ zod-validation-error@^3.5.2:
   resolved "https://registry.yarnpkg.com/zod-validation-error/-/zod-validation-error-3.5.3.tgz#85ba33290200d8db9f043621e284f40dddefb7e5"
   integrity sha512-OT5Y8lbUadqVZCsnyFaTQ4/O2mys4tj7PqhdbBCp7McPwvIEKfPtdA6QfPeFQK2/Rz5LgwmAXRJTugBNBi0btw==
 
-zod@^3.25.67, zod@^3.25.76:
+zod@^3.25.67:
   version "3.25.76"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.76.tgz#26841c3f6fd22a6a2760e7ccb719179768471e34"
   integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==


### PR DESCRIPTION
- Updated package.json to include @discloudapp/api-types and @discloudapp/util dependencies.
- Refactored imports across multiple files to replace discloud.app with @discloudapp/api-types and @discloudapp/util.
- Adjusted function calls and types to align with the new API structure.
- Removed obsolete dependencies related to discloud.app.