### PR TITLE
fix(REST): keep rate-limit reset timer in sync with the reported window

### DIFF
--- a/src/services/discloud/REST.ts
+++ b/src/services/discloud/REST.ts
@@ -94,7 +94,10 @@ export default class REST extends EventEmitter {
     if (inQueue) {
       await this.#queue.wait(processKey);
 
-      if (this.limited) return null;
+      if (this.limited) {
+        this.#queue.shift(processKey);
+        return null;
+      }
     } else {
       if (this.#noQueueProcesses.length) {
         void window.showErrorMessage(t("process.already.running", this.#noQueueProcesses.length));
@@ -221,14 +224,15 @@ export default class REST extends EventEmitter {
     const Reset = parseInt(headers.get("ratelimit-reset")!);
     if (!isNaN(Limit)) this.limit = Math.max(Limit, 0);
     if (!isNaN(Remaining)) this.remaining = Math.max(Remaining, 0);
-    if (!isNaN(Reset)) this.reset = Math.max(Reset, 0);
-
-    this.#initRateLimitResetTimer();
+    if (!isNaN(Reset)) {
+      this.reset = Math.max(Reset, 0);
+      this.#initRateLimitResetTimer();
+    }
   }
 
   #timer!: NodeJS.Timeout | null;
   #initRateLimitResetTimer() {
-    if (this.#timer) return;
+    if (this.#timer) clearTimeout(this.#timer);
     this.#timer = setTimeout(() => {
       this.#timer = null;
       this.remaining = this.limit;


### PR DESCRIPTION
## Bug

The rate-limit reset timer is scheduled **once**, using the delay computed from the first response's `ratelimit-reset` header, and is never rescheduled (`if (this.#timer) return;`).

`#resolveResponseHeaders` keeps updating `limit`/`remaining`/`reset` on every response, but the timer keeps its original deadline. When the server shortens (or otherwise changes) the window, the local `remaining` stays `0` past the real window boundary, so `get limited()` (`remaining < 1`) wrongly rejects the **first requests of the new window** - the same class of "stale counter after window reset" bug fixed in OmniRoute (PR #9241).

## Fix

- **Reschedule** the reset timer whenever a response reports a valid `ratelimit-reset` (`clearTimeout` + re-schedule), so the counter is reset in sync with the latest reported window.
- Only (re)schedule when a numeric `reset` is present, so header-less responses don't shift the deadline.

## Also fixed (same code path)

When an enqueued request (`queueGet`/`queuePost`/...) finds itself rate-limited right after acquiring the queue lock, it returned `null` **without releasing the lock** (`#queue.shift`), permanently deadlocking every later request for that `processKey`. It now shifts the queue before returning.

## Verification

- `tsc --noEmit` - clean
- `eslint src` - clean